### PR TITLE
feat: AI 자연어 명령 처리 기능 구현

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,31 +1,150 @@
-# Phase 4.5: Swagger + 테스트 코드 구현 계획
+# Phase 5: AI 자연어 명령 (Java 재구현)
+
+## Context
+기존 Python(FastAPI) 백엔드에 내장된 AI/NLP 기능을 Java Spring Boot로 재구현한다.
+Python 워커는 독립 서비스가 아니라 FastAPI에 내장되어 있었으므로, Java에서도 동일하게 백엔드에 내장한다.
+Gemini REST API를 직접 호출하고, 파싱된 Intent를 기존 Java 서비스(DeploymentService, RepositoryService)에 디스패치한다.
 
 ## Git 워크플로우
 1. main 체크아웃 + pull
-2. GitHub 이슈 생성 (gh CLI 설치 후)
-3. `feat/#9-test-swagger` 브랜치 생성
+2. GitHub 이슈 생성
+3. `feat/#N-ai-nlp` 브랜치 생성
 4. 구현
 5. 커밋 + 푸시 + PR 생성
 
+## 아키텍처
+
+```
+사용자 → POST /api/v1/nlp/command → NlpController
+    → NlpCommandService (오케스트레이터)
+        → GeminiClient (Gemini REST API 호출)
+        → IntentParser (JSON 응답 → ParsedIntent)
+        → ActionDispatcher (Intent → 기존 서비스 메서드 호출)
+        → CommandLog DB 저장
+    → 응답 반환
+```
+
+## 신규 파일 (20개)
+
+### Entity & Enum
+| 파일 | 설명 |
+|------|------|
+| `ai/entity/Intent.java` | DEPLOY, SCALE, RESTART, STATUS, LOGS, LIST_DEPLOYMENTS, LIST_REPOSITORIES, OVERVIEW, HELP, UNKNOWN |
+| `ai/entity/RiskLevel.java` | LOW, MEDIUM, HIGH |
+| `ai/entity/ConversationSession.java` | 대화 세션 엔티티 (sessionToken UUID, active, lastActiveAt) |
+
+### Client
+| 파일 | 설명 |
+|------|------|
+| `ai/config/GeminiConfig.java` | geminiRestClient Bean 설정 |
+| `ai/client/GeminiClient.java` | Gemini REST API 호출 (RestClient 패턴) |
+| `ai/client/dto/GeminiRequest.java` | Gemini API 요청 record |
+| `ai/client/dto/GeminiResponse.java` | Gemini API 응답 record |
+
+### Service
+| 파일 | 설명 |
+|------|------|
+| `ai/service/NlpCommandService.java` | 핵심 오케스트레이터 (프롬프트 구성 → Gemini 호출 → 파싱 → 리스크 판단 → 실행/대기) |
+| `ai/service/IntentParser.java` | Gemini JSON 응답을 ParsedIntent로 변환 (마크다운 코드블록 처리 포함) |
+| `ai/service/ActionDispatcher.java` | Intent → 기존 서비스 메서드 매핑 + 리스크 분류 |
+
+### DTO
+| 파일 | 설명 |
+|------|------|
+| `ai/dto/NlpCommandRequest.java` | `{command, sessionId?}` |
+| `ai/dto/NlpCommandResponse.java` | `{commandLogId, intent, message, result, riskLevel, requiresConfirmation, sessionId}` |
+| `ai/dto/NlpConfirmRequest.java` | `{commandLogId, confirmed}` |
+| `ai/dto/ParsedIntent.java` | 내부용: `{intent, args, confidence, message}` |
+| `ai/dto/CommandLogResponse.java` | 이력 조회 응답 |
+
+### Controller & Repository & Exception
+| 파일 | 설명 |
+|------|------|
+| `ai/controller/NlpController.java` | `POST /command`, `POST /confirm`, `GET /history` |
+| `ai/repository/CommandLogRepository.java` | JPA Repository |
+| `ai/repository/ConversationSessionRepository.java` | JPA Repository |
+| `ai/exception/AiProcessingException.java` | BusinessException 서브클래스 |
+
+### Resource
+| 파일 | 설명 |
+|------|------|
+| `src/main/resources/prompts/system-prompt.txt` | 시스템 프롬프트 (Intent 정의, JSON 응답 형식, 한국어 처리 규칙) |
+
+## 수정 파일 (3개)
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `ai/entity/CommandLog.java` | 필드 추가: intentArgs, riskLevel, requiresConfirmation, confirmed, executionResult, aiResponse, session / interpretedIntent를 String→Intent enum 변경 |
+| `global/exception/ErrorCode.java` | AI_API_ERROR, AI_PARSE_ERROR, COMMAND_LOG_NOT_FOUND, SESSION_NOT_FOUND 추가 |
+| `application.yaml` | `gemini.api.base-url`, `gemini.api.key`, `gemini.api.model` 설정 추가 |
+
+## 테스트 파일 (5개)
+
+| 파일 | 유형 |
+|------|------|
+| `ai/service/IntentParserTest.java` | Unit (JSON 파싱, 마크다운 처리, 잘못된 응답 처리) |
+| `ai/service/ActionDispatcherTest.java` | Unit (리스크 분류, 서비스 메서드 호출 검증) |
+| `ai/service/NlpCommandServiceTest.java` | Unit (LOW 자동실행, MEDIUM/HIGH 확인 대기, 확인/취소 흐름) |
+| `ai/client/GeminiClientTest.java` | Unit (RestClient 모킹) |
+| `ai/controller/NlpControllerTest.java` | WebMvcTest (인증, 요청/응답 구조 검증) |
+
+## API 엔드포인트
+
+| Method | URL | 설명 | 인증 |
+|--------|-----|------|------|
+| POST | `/api/v1/nlp/command` | 자연어 명령 처리 | 필요 |
+| POST | `/api/v1/nlp/confirm` | 위험 명령 확인/취소 | 필요 |
+| GET | `/api/v1/nlp/history` | 명령 이력 조회 (페이징) | 필요 |
+
+## 리스크 분류
+
+| Risk | Intent | 동작 |
+|------|--------|------|
+| LOW | STATUS, LOGS, LIST_DEPLOYMENTS, LIST_REPOSITORIES, OVERVIEW, HELP, UNKNOWN | 즉시 실행 |
+| MEDIUM | SCALE, RESTART | 확인 후 실행 |
+| HIGH | DEPLOY | 확인 후 실행 |
+
 ## 구현 순서
 
-### Step 1: build.gradle 의존성 추가
-- `org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0`
-- `org.springframework.boot:spring-boot-starter-test`
-- `org.springframework.security:spring-security-test`
+### Step 1: 설정 및 기반
+- application.yaml에 gemini 설정 추가
+- ErrorCode에 AI 에러 코드 추가
+- GeminiConfig, GeminiRequest, GeminiResponse, AiProcessingException 생성
 
-### Step 2: Swagger 설정
-- `global/config/SwaggerConfig.java` 생성 (OpenAPI + JWT BearerAuth SecurityScheme)
-- `SecurityConfig.java` 수정: `/swagger-ui/**`, `/v3/api-docs/**` permitAll 추가
+### Step 2: Entity, Enum, Repository
+- Intent, RiskLevel enum 생성
+- CommandLog 엔티티 수정 (필드 추가)
+- ConversationSession 엔티티 생성
+- CommandLogRepository, ConversationSessionRepository 생성
 
-### Step 3: 서비스 단위 테스트 (Mockito)
-- `DeploymentServiceTest.java` — createDeployment, getDeployment, getDeploymentStatus
-- `RepositoryServiceTest.java` — createRepository, getRepositories, deleteRepository, updateDeploymentConfig
-- `AuthServiceTest.java` — login, refresh, getOAuthUrl
+### Step 3: Gemini Client + IntentParser
+- GeminiClient 생성
+- IntentParser 생성
+- IntentParserTest 작성 및 실행
 
-### Step 4: 컨트롤러 통합 테스트 (MockMvc)
-- `DeploymentControllerTest.java` — POST /deployments, GET /deployments, GET /deployments/{id}/status
-- `RepositoryControllerTest.java` — POST/GET/DELETE /repositories, PUT /repositories/{id}/config
-- `AuthControllerTest.java` — GET /auth/oauth2/url, POST /auth/oauth2/login, POST /auth/refresh
+### Step 4: ActionDispatcher
+- ActionDispatcher 생성
+- ActionDispatcherTest 작성 및 실행
 
-### Step 5: 커밋 + 푸시 + PR 생성
+### Step 5: DTO
+- NlpCommandRequest, NlpCommandResponse, NlpConfirmRequest, ParsedIntent, CommandLogResponse 생성
+
+### Step 6: NlpCommandService + 시스템 프롬프트
+- system-prompt.txt 생성
+- NlpCommandService 생성
+- NlpCommandServiceTest 작성 및 실행
+
+### Step 7: Controller
+- NlpController 생성
+- NlpControllerTest 작성 및 실행
+
+### Step 8: 전체 검증
+- `./gradlew test` 전체 테스트 통과 확인
+- 애플리케이션 기동 확인
+
+## 개선 사항 (기존 Python 대비)
+- 시스템 프롬프트를 별도 리소스 파일로 분리 (Python: 코드 내 337행 하드코딩)
+- Redis 제거 → DB 기반 세션 관리로 단순화
+- Gemini 모델명 설정으로 외부화 (Python: 하드코딩)
+- Intent를 enum으로 타입 안전하게 관리
+- 기존 Java 서비스와 직접 연동 (Python: K8s 직접 조작 → Java: 서비스 레이어 통해 실행)

--- a/src/main/java/klepaas/backend/ai/client/GeminiClient.java
+++ b/src/main/java/klepaas/backend/ai/client/GeminiClient.java
@@ -1,0 +1,46 @@
+package klepaas.backend.ai.client;
+
+import klepaas.backend.ai.client.dto.GeminiRequest;
+import klepaas.backend.ai.client.dto.GeminiResponse;
+import klepaas.backend.ai.exception.AiProcessingException;
+import klepaas.backend.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class GeminiClient {
+
+    private final RestClient geminiRestClient;
+    private final String apiKey;
+    private final String model;
+
+    public GeminiClient(
+            @Qualifier("geminiRestClient") RestClient geminiRestClient,
+            @Value("${gemini.api.key}") String apiKey,
+            @Value("${gemini.api.model}") String model
+    ) {
+        this.geminiRestClient = geminiRestClient;
+        this.apiKey = apiKey;
+        this.model = model;
+    }
+
+    public GeminiResponse generate(GeminiRequest request) {
+        String uri = "/v1beta/models/" + model + ":generateContent?key=" + apiKey;
+
+        return geminiRestClient.post()
+                .uri(uri)
+                .body(request)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> {
+                    log.error("Gemini API 호출 실패: status={}", res.getStatusCode());
+                    throw new AiProcessingException(ErrorCode.AI_API_ERROR,
+                            "Gemini API 호출 실패: " + res.getStatusCode());
+                })
+                .body(GeminiResponse.class);
+    }
+}

--- a/src/main/java/klepaas/backend/ai/client/dto/GeminiRequest.java
+++ b/src/main/java/klepaas/backend/ai/client/dto/GeminiRequest.java
@@ -1,0 +1,44 @@
+package klepaas.backend.ai.client.dto;
+
+import java.util.List;
+
+public record GeminiRequest(
+        List<Content> contents,
+        GenerationConfig generationConfig
+) {
+    public record Content(
+            String role,
+            List<Part> parts
+    ) {
+    }
+
+    public record Part(
+            String text
+    ) {
+    }
+
+    public record GenerationConfig(
+            double temperature,
+            int maxOutputTokens
+    ) {
+    }
+
+    public static GeminiRequest of(String systemPrompt, String userMessage) {
+        return new GeminiRequest(
+                List.of(
+                        new Content("user", List.of(
+                                new Part(systemPrompt + "\n\n사용자 입력: " + userMessage)
+                        ))
+                ),
+                new GenerationConfig(0.1, 1024)
+        );
+    }
+
+    public static GeminiRequest withHistory(String systemPrompt, List<Content> history, String userMessage) {
+        var contents = new java.util.ArrayList<>(history);
+        contents.add(new Content("user", List.of(
+                new Part(systemPrompt + "\n\n사용자 입력: " + userMessage)
+        )));
+        return new GeminiRequest(contents, new GenerationConfig(0.1, 1024));
+    }
+}

--- a/src/main/java/klepaas/backend/ai/client/dto/GeminiResponse.java
+++ b/src/main/java/klepaas/backend/ai/client/dto/GeminiResponse.java
@@ -1,0 +1,34 @@
+package klepaas.backend.ai.client.dto;
+
+import java.util.List;
+
+public record GeminiResponse(
+        List<Candidate> candidates
+) {
+    public record Candidate(
+            Content content
+    ) {
+    }
+
+    public record Content(
+            List<Part> parts,
+            String role
+    ) {
+    }
+
+    public record Part(
+            String text
+    ) {
+    }
+
+    public String extractText() {
+        if (candidates == null || candidates.isEmpty()) {
+            return "";
+        }
+        Candidate candidate = candidates.get(0);
+        if (candidate.content() == null || candidate.content().parts() == null || candidate.content().parts().isEmpty()) {
+            return "";
+        }
+        return candidate.content().parts().get(0).text();
+    }
+}

--- a/src/main/java/klepaas/backend/ai/config/GeminiConfig.java
+++ b/src/main/java/klepaas/backend/ai/config/GeminiConfig.java
@@ -1,0 +1,21 @@
+package klepaas.backend.ai.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class GeminiConfig {
+
+    @Value("${gemini.api.base-url}")
+    private String baseUrl;
+
+    @Bean
+    public RestClient geminiRestClient() {
+        return RestClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/src/main/java/klepaas/backend/ai/controller/NlpController.java
+++ b/src/main/java/klepaas/backend/ai/controller/NlpController.java
@@ -1,0 +1,45 @@
+package klepaas.backend.ai.controller;
+
+import jakarta.validation.Valid;
+import klepaas.backend.ai.dto.CommandLogResponse;
+import klepaas.backend.ai.dto.NlpCommandRequest;
+import klepaas.backend.ai.dto.NlpCommandResponse;
+import klepaas.backend.ai.dto.NlpConfirmRequest;
+import klepaas.backend.ai.service.NlpCommandService;
+import klepaas.backend.auth.config.CustomUserDetails;
+import klepaas.backend.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/nlp")
+@RequiredArgsConstructor
+public class NlpController {
+
+    private final NlpCommandService nlpCommandService;
+
+    @PostMapping("/command")
+    public ApiResponse<NlpCommandResponse> processCommand(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody NlpCommandRequest request) {
+        return ApiResponse.success(nlpCommandService.processCommand(userDetails.getUserId(), request));
+    }
+
+    @PostMapping("/confirm")
+    public ApiResponse<NlpCommandResponse> confirmCommand(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody NlpConfirmRequest request) {
+        return ApiResponse.success(nlpCommandService.confirmCommand(userDetails.getUserId(), request));
+    }
+
+    @GetMapping("/history")
+    public ApiResponse<Page<CommandLogResponse>> getHistory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(size = 20) Pageable pageable) {
+        return ApiResponse.success(nlpCommandService.getHistory(userDetails.getUserId(), pageable));
+    }
+}

--- a/src/main/java/klepaas/backend/ai/dto/CommandLogResponse.java
+++ b/src/main/java/klepaas/backend/ai/dto/CommandLogResponse.java
@@ -1,0 +1,31 @@
+package klepaas.backend.ai.dto;
+
+import klepaas.backend.ai.entity.CommandLog;
+import klepaas.backend.ai.entity.Intent;
+import klepaas.backend.ai.entity.RiskLevel;
+
+import java.time.LocalDateTime;
+
+public record CommandLogResponse(
+        Long id,
+        String rawCommand,
+        Intent intent,
+        RiskLevel riskLevel,
+        boolean isExecuted,
+        String executionResult,
+        String errorMessage,
+        LocalDateTime createdAt
+) {
+    public static CommandLogResponse from(CommandLog entity) {
+        return new CommandLogResponse(
+                entity.getId(),
+                entity.getRawCommand(),
+                entity.getInterpretedIntent(),
+                entity.getRiskLevel(),
+                entity.isExecuted(),
+                entity.getExecutionResult(),
+                entity.getErrorMessage(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/klepaas/backend/ai/dto/NlpCommandRequest.java
+++ b/src/main/java/klepaas/backend/ai/dto/NlpCommandRequest.java
@@ -1,0 +1,9 @@
+package klepaas.backend.ai.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NlpCommandRequest(
+        @NotBlank String command,
+        String sessionId
+) {
+}

--- a/src/main/java/klepaas/backend/ai/dto/NlpCommandResponse.java
+++ b/src/main/java/klepaas/backend/ai/dto/NlpCommandResponse.java
@@ -1,0 +1,15 @@
+package klepaas.backend.ai.dto;
+
+import klepaas.backend.ai.entity.Intent;
+import klepaas.backend.ai.entity.RiskLevel;
+
+public record NlpCommandResponse(
+        Long commandLogId,
+        Intent intent,
+        String message,
+        String result,
+        RiskLevel riskLevel,
+        boolean requiresConfirmation,
+        String sessionId
+) {
+}

--- a/src/main/java/klepaas/backend/ai/dto/NlpConfirmRequest.java
+++ b/src/main/java/klepaas/backend/ai/dto/NlpConfirmRequest.java
@@ -1,0 +1,10 @@
+package klepaas.backend.ai.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record NlpConfirmRequest(
+        @NotNull Long commandLogId,
+        boolean confirmed,
+        String gitToken
+) {
+}

--- a/src/main/java/klepaas/backend/ai/dto/ParsedIntent.java
+++ b/src/main/java/klepaas/backend/ai/dto/ParsedIntent.java
@@ -1,0 +1,13 @@
+package klepaas.backend.ai.dto;
+
+import klepaas.backend.ai.entity.Intent;
+
+import java.util.Map;
+
+public record ParsedIntent(
+        Intent intent,
+        Map<String, Object> args,
+        double confidence,
+        String message
+) {
+}

--- a/src/main/java/klepaas/backend/ai/entity/CommandLog.java
+++ b/src/main/java/klepaas/backend/ai/entity/CommandLog.java
@@ -23,20 +23,63 @@ public class CommandLog extends BaseTimeEntity {
     private User user;
 
     @Column(nullable = false)
-    private String rawCommand; // "nginx 3개로 늘려줘"
+    private String rawCommand;
 
-    private String interpretedIntent; // "SCALE"
+    @Enumerated(EnumType.STRING)
+    private Intent interpretedIntent;
 
-    private boolean isExecuted; // 실제 실행 여부
+    @Column(columnDefinition = "TEXT")
+    private String intentArgs;
+
+    @Enumerated(EnumType.STRING)
+    private RiskLevel riskLevel;
+
+    private boolean requiresConfirmation;
+
+    private boolean confirmed;
+
+    private boolean isExecuted;
+
+    @Column(columnDefinition = "TEXT")
+    private String executionResult;
+
+    @Column(columnDefinition = "TEXT")
+    private String aiResponse;
 
     private String errorMessage;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private ConversationSession session;
+
     @Builder
-    public CommandLog(User user, String rawCommand, String interpretedIntent, boolean isExecuted, String errorMessage) {
+    public CommandLog(User user, String rawCommand, Intent interpretedIntent,
+                      String intentArgs, RiskLevel riskLevel, boolean requiresConfirmation,
+                      boolean isExecuted, String errorMessage, String aiResponse,
+                      ConversationSession session) {
         this.user = user;
         this.rawCommand = rawCommand;
         this.interpretedIntent = interpretedIntent;
+        this.intentArgs = intentArgs;
+        this.riskLevel = riskLevel;
+        this.requiresConfirmation = requiresConfirmation;
         this.isExecuted = isExecuted;
         this.errorMessage = errorMessage;
+        this.aiResponse = aiResponse;
+        this.session = session;
+    }
+
+    public void markExecuted(String executionResult) {
+        this.isExecuted = true;
+        this.executionResult = executionResult;
+    }
+
+    public void markFailed(String errorMessage) {
+        this.isExecuted = false;
+        this.errorMessage = errorMessage;
+    }
+
+    public void confirm(boolean confirmed) {
+        this.confirmed = confirmed;
     }
 }

--- a/src/main/java/klepaas/backend/ai/entity/ConversationSession.java
+++ b/src/main/java/klepaas/backend/ai/entity/ConversationSession.java
@@ -1,0 +1,51 @@
+package klepaas.backend.ai.entity;
+
+import jakarta.persistence.*;
+import klepaas.backend.global.entity.BaseTimeEntity;
+import klepaas.backend.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "conversation_session")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConversationSession extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String sessionToken;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    private LocalDateTime lastActiveAt;
+
+    @Builder
+    public ConversationSession(User user) {
+        this.user = user;
+        this.sessionToken = UUID.randomUUID().toString();
+        this.active = true;
+        this.lastActiveAt = LocalDateTime.now();
+    }
+
+    public void touch() {
+        this.lastActiveAt = LocalDateTime.now();
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+}

--- a/src/main/java/klepaas/backend/ai/entity/Intent.java
+++ b/src/main/java/klepaas/backend/ai/entity/Intent.java
@@ -1,0 +1,14 @@
+package klepaas.backend.ai.entity;
+
+public enum Intent {
+    DEPLOY,
+    SCALE,
+    RESTART,
+    STATUS,
+    LOGS,
+    LIST_DEPLOYMENTS,
+    LIST_REPOSITORIES,
+    OVERVIEW,
+    HELP,
+    UNKNOWN
+}

--- a/src/main/java/klepaas/backend/ai/entity/RiskLevel.java
+++ b/src/main/java/klepaas/backend/ai/entity/RiskLevel.java
@@ -1,0 +1,7 @@
+package klepaas.backend.ai.entity;
+
+public enum RiskLevel {
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/src/main/java/klepaas/backend/ai/exception/AiProcessingException.java
+++ b/src/main/java/klepaas/backend/ai/exception/AiProcessingException.java
@@ -1,0 +1,15 @@
+package klepaas.backend.ai.exception;
+
+import klepaas.backend.global.exception.BusinessException;
+import klepaas.backend.global.exception.ErrorCode;
+
+public class AiProcessingException extends BusinessException {
+
+    public AiProcessingException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AiProcessingException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/klepaas/backend/ai/repository/CommandLogRepository.java
+++ b/src/main/java/klepaas/backend/ai/repository/CommandLogRepository.java
@@ -1,0 +1,11 @@
+package klepaas.backend.ai.repository;
+
+import klepaas.backend.ai.entity.CommandLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommandLogRepository extends JpaRepository<CommandLog, Long> {
+
+    Page<CommandLog> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/klepaas/backend/ai/repository/ConversationSessionRepository.java
+++ b/src/main/java/klepaas/backend/ai/repository/ConversationSessionRepository.java
@@ -1,0 +1,11 @@
+package klepaas.backend.ai.repository;
+
+import klepaas.backend.ai.entity.ConversationSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ConversationSessionRepository extends JpaRepository<ConversationSession, Long> {
+
+    Optional<ConversationSession> findBySessionTokenAndActiveTrue(String sessionToken);
+}

--- a/src/main/java/klepaas/backend/ai/service/ActionDispatcher.java
+++ b/src/main/java/klepaas/backend/ai/service/ActionDispatcher.java
@@ -1,0 +1,139 @@
+package klepaas.backend.ai.service;
+
+import klepaas.backend.ai.dto.ParsedIntent;
+import klepaas.backend.ai.entity.Intent;
+import klepaas.backend.ai.entity.RiskLevel;
+import klepaas.backend.deployment.dto.CreateDeploymentRequest;
+import klepaas.backend.deployment.dto.ScaleRequest;
+import klepaas.backend.deployment.service.DeploymentService;
+import klepaas.backend.deployment.service.RepositoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActionDispatcher {
+
+    private final DeploymentService deploymentService;
+    private final RepositoryService repositoryService;
+
+    public RiskLevel classifyRisk(Intent intent) {
+        return switch (intent) {
+            case DEPLOY -> RiskLevel.HIGH;
+            case SCALE, RESTART -> RiskLevel.MEDIUM;
+            default -> RiskLevel.LOW;
+        };
+    }
+
+    public String dispatch(ParsedIntent parsedIntent, Long userId, String gitToken) {
+        Map<String, Object> args = parsedIntent.args();
+        log.info("Action 실행: intent={}, args={}", parsedIntent.intent(), args);
+
+        return switch (parsedIntent.intent()) {
+            case DEPLOY -> executeDeploy(args, gitToken);
+            case SCALE -> executeScale(args);
+            case RESTART -> executeRestart(args);
+            case STATUS -> executeStatus(args);
+            case LOGS -> executeLogs(args);
+            case LIST_DEPLOYMENTS -> executeListDeployments(args);
+            case LIST_REPOSITORIES -> executeListRepositories(userId);
+            case OVERVIEW -> executeOverview(userId);
+            case HELP -> executeHelp();
+            case UNKNOWN -> parsedIntent.message();
+        };
+    }
+
+    private String executeDeploy(Map<String, Object> args, String gitToken) {
+        Long repositoryId = toLong(args.get("repository_id"));
+        String branchName = (String) args.getOrDefault("branch_name", "main");
+        String commitHash = (String) args.getOrDefault("commit_hash", "HEAD");
+
+        var request = new CreateDeploymentRequest(repositoryId, branchName, commitHash, gitToken);
+        var response = deploymentService.createDeployment(request);
+        return "배포가 시작되었습니다. 배포 ID: " + response.id() + ", 상태: " + response.status();
+    }
+
+    private String executeScale(Map<String, Object> args) {
+        Long deploymentId = toLong(args.get("deployment_id"));
+        int replicas = ((Number) args.getOrDefault("replicas", 1)).intValue();
+
+        deploymentService.scaleDeployment(deploymentId, new ScaleRequest(replicas));
+        return "스케일링 완료: 배포 ID " + deploymentId + " → " + replicas + "개 레플리카";
+    }
+
+    private String executeRestart(Map<String, Object> args) {
+        Long deploymentId = toLong(args.get("deployment_id"));
+        deploymentService.restartDeployment(deploymentId);
+        return "재시작 완료: 배포 ID " + deploymentId;
+    }
+
+    private String executeStatus(Map<String, Object> args) {
+        Long deploymentId = toLong(args.get("deployment_id"));
+        var status = deploymentService.getDeploymentStatus(deploymentId);
+        return "배포 ID " + deploymentId + " 상태: " + status.status();
+    }
+
+    private String executeLogs(Map<String, Object> args) {
+        Long deploymentId = toLong(args.get("deployment_id"));
+        var logs = deploymentService.getDeploymentLogs(deploymentId);
+        return "배포 ID " + deploymentId + " 로그:\n" + String.join("\n", logs.logs());
+    }
+
+    private String executeListDeployments(Map<String, Object> args) {
+        Long repositoryId = toLong(args.get("repository_id"));
+        var deployments = deploymentService.getDeployments(repositoryId,
+                org.springframework.data.domain.PageRequest.of(0, 10));
+        if (deployments.isEmpty()) {
+            return "해당 저장소에 배포 이력이 없습니다.";
+        }
+        var sb = new StringBuilder("배포 목록:\n");
+        deployments.forEach(d -> sb.append("- ID: ").append(d.id())
+                .append(", 상태: ").append(d.status())
+                .append(", 브랜치: ").append(d.branchName()).append("\n"));
+        return sb.toString();
+    }
+
+    private String executeListRepositories(Long userId) {
+        var repos = repositoryService.getRepositories(userId);
+        if (repos.isEmpty()) {
+            return "등록된 저장소가 없습니다.";
+        }
+        var sb = new StringBuilder("저장소 목록:\n");
+        repos.forEach(r -> sb.append("- ID: ").append(r.id())
+                .append(", 이름: ").append(r.owner()).append("/").append(r.repoName()).append("\n"));
+        return sb.toString();
+    }
+
+    private String executeOverview(Long userId) {
+        var repos = repositoryService.getRepositories(userId);
+        return "프로젝트 개요:\n- 등록된 저장소 수: " + repos.size();
+    }
+
+    private String executeHelp() {
+        return """
+                사용 가능한 명령어:
+                - "내 프로젝트 배포해줘" → 배포 실행
+                - "레플리카 3개로 늘려줘" → 스케일링
+                - "서비스 재시작해줘" → 재시작
+                - "배포 상태 알려줘" → 상태 조회
+                - "로그 보여줘" → 로그 조회
+                - "배포 목록" → 배포 이력 조회
+                - "저장소 목록" → 저장소 목록 조회
+                - "전체 현황" → 프로젝트 개요
+                """;
+    }
+
+    private Long toLong(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value instanceof String str) {
+            return Long.parseLong(str);
+        }
+        throw new IllegalArgumentException("Long으로 변환할 수 없는 값: " + value);
+    }
+}

--- a/src/main/java/klepaas/backend/ai/service/IntentParser.java
+++ b/src/main/java/klepaas/backend/ai/service/IntentParser.java
@@ -1,0 +1,70 @@
+package klepaas.backend.ai.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import klepaas.backend.ai.dto.ParsedIntent;
+import klepaas.backend.ai.entity.Intent;
+import klepaas.backend.ai.exception.AiProcessingException;
+import klepaas.backend.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+public class IntentParser {
+
+    private static final Pattern CODE_BLOCK_PATTERN = Pattern.compile("```(?:json)?\\s*\\n?(.*?)\\n?```", Pattern.DOTALL);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public ParsedIntent parse(String geminiResponseText) {
+        String jsonStr = extractJson(geminiResponseText);
+
+        try {
+            Map<String, Object> parsed = objectMapper.readValue(jsonStr, new TypeReference<>() {});
+
+            String intentStr = ((String) parsed.getOrDefault("intent", "UNKNOWN")).toUpperCase();
+            Intent intent;
+            try {
+                intent = Intent.valueOf(intentStr);
+            } catch (IllegalArgumentException e) {
+                intent = Intent.UNKNOWN;
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> args = (Map<String, Object>) parsed.getOrDefault("args", Map.of());
+            double confidence = ((Number) parsed.getOrDefault("confidence", 0.0)).doubleValue();
+            String message = (String) parsed.getOrDefault("message", "");
+
+            return new ParsedIntent(intent, args, confidence, message);
+        } catch (Exception e) {
+            log.error("AI 응답 파싱 실패: {}", geminiResponseText, e);
+            throw new AiProcessingException(ErrorCode.AI_PARSE_ERROR,
+                    "AI 응답 파싱 실패: " + e.getMessage());
+        }
+    }
+
+    private String extractJson(String text) {
+        if (text == null || text.isBlank()) {
+            throw new AiProcessingException(ErrorCode.AI_PARSE_ERROR, "AI 응답이 비어 있습니다");
+        }
+
+        // 마크다운 코드블록 안에 JSON이 있는 경우
+        Matcher matcher = CODE_BLOCK_PATTERN.matcher(text);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+
+        // 코드블록 없이 바로 JSON인 경우
+        String trimmed = text.trim();
+        if (trimmed.startsWith("{")) {
+            return trimmed;
+        }
+
+        throw new AiProcessingException(ErrorCode.AI_PARSE_ERROR,
+                "AI 응답에서 JSON을 추출할 수 없습니다: " + text.substring(0, Math.min(text.length(), 100)));
+    }
+}

--- a/src/main/java/klepaas/backend/ai/service/NlpCommandService.java
+++ b/src/main/java/klepaas/backend/ai/service/NlpCommandService.java
@@ -1,0 +1,202 @@
+package klepaas.backend.ai.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import klepaas.backend.ai.client.GeminiClient;
+import klepaas.backend.ai.client.dto.GeminiRequest;
+import klepaas.backend.ai.client.dto.GeminiResponse;
+import klepaas.backend.ai.dto.*;
+import klepaas.backend.ai.entity.*;
+import klepaas.backend.ai.exception.AiProcessingException;
+import klepaas.backend.ai.repository.CommandLogRepository;
+import klepaas.backend.ai.repository.ConversationSessionRepository;
+import klepaas.backend.global.exception.EntityNotFoundException;
+import klepaas.backend.global.exception.ErrorCode;
+import klepaas.backend.user.entity.User;
+import klepaas.backend.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+public class NlpCommandService {
+
+    private final GeminiClient geminiClient;
+    private final IntentParser intentParser;
+    private final ActionDispatcher actionDispatcher;
+    private final CommandLogRepository commandLogRepository;
+    private final ConversationSessionRepository sessionRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String systemPrompt;
+
+    public NlpCommandService(
+            GeminiClient geminiClient,
+            IntentParser intentParser,
+            ActionDispatcher actionDispatcher,
+            CommandLogRepository commandLogRepository,
+            ConversationSessionRepository sessionRepository,
+            UserRepository userRepository,
+            @Value("classpath:prompts/system-prompt.txt") Resource systemPromptResource
+    ) {
+        this.geminiClient = geminiClient;
+        this.intentParser = intentParser;
+        this.actionDispatcher = actionDispatcher;
+        this.commandLogRepository = commandLogRepository;
+        this.sessionRepository = sessionRepository;
+        this.userRepository = userRepository;
+        try {
+            this.systemPrompt = systemPromptResource.getContentAsString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("시스템 프롬프트 파일을 읽을 수 없습니다", e);
+        }
+    }
+
+    @Transactional
+    public NlpCommandResponse processCommand(Long userId, NlpCommandRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        // 세션 관리
+        ConversationSession session = getOrCreateSession(user, request.sessionId());
+
+        // Gemini API 호출
+        GeminiRequest geminiRequest = GeminiRequest.of(systemPrompt, request.command());
+        GeminiResponse geminiResponse = geminiClient.generate(geminiRequest);
+        String responseText = geminiResponse.extractText();
+
+        // Intent 파싱
+        ParsedIntent parsedIntent = intentParser.parse(responseText);
+
+        // 리스크 분류
+        RiskLevel riskLevel = actionDispatcher.classifyRisk(parsedIntent.intent());
+        boolean requiresConfirmation = riskLevel != RiskLevel.LOW;
+
+        // 인자 직렬화
+        String intentArgsJson = serializeArgs(parsedIntent);
+
+        // CommandLog 저장
+        CommandLog commandLog = CommandLog.builder()
+                .user(user)
+                .rawCommand(request.command())
+                .interpretedIntent(parsedIntent.intent())
+                .intentArgs(intentArgsJson)
+                .riskLevel(riskLevel)
+                .requiresConfirmation(requiresConfirmation)
+                .aiResponse(responseText)
+                .session(session)
+                .build();
+        commandLogRepository.save(commandLog);
+
+        // LOW 리스크는 즉시 실행
+        String result = null;
+        if (!requiresConfirmation) {
+            try {
+                result = actionDispatcher.dispatch(parsedIntent, userId, null);
+                commandLog.markExecuted(result);
+            } catch (Exception e) {
+                log.error("명령 실행 실패: intent={}", parsedIntent.intent(), e);
+                commandLog.markFailed(e.getMessage());
+                result = "명령 실행 중 오류가 발생했습니다: " + e.getMessage();
+            }
+        }
+
+        session.touch();
+
+        return new NlpCommandResponse(
+                commandLog.getId(),
+                parsedIntent.intent(),
+                parsedIntent.message(),
+                result,
+                riskLevel,
+                requiresConfirmation,
+                session.getSessionToken()
+        );
+    }
+
+    @Transactional
+    public NlpCommandResponse confirmCommand(Long userId, NlpConfirmRequest request) {
+        CommandLog commandLog = commandLogRepository.findById(request.commandLogId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.COMMAND_LOG_NOT_FOUND));
+
+        commandLog.confirm(request.confirmed());
+
+        if (!request.confirmed()) {
+            return new NlpCommandResponse(
+                    commandLog.getId(),
+                    commandLog.getInterpretedIntent(),
+                    "명령이 취소되었습니다.",
+                    null,
+                    commandLog.getRiskLevel(),
+                    false,
+                    commandLog.getSession() != null ? commandLog.getSession().getSessionToken() : null
+            );
+        }
+
+        // 저장된 Intent 정보로 실행
+        ParsedIntent parsedIntent = deserializeParsedIntent(commandLog);
+        String result;
+        try {
+            result = actionDispatcher.dispatch(parsedIntent, userId, request.gitToken());
+            commandLog.markExecuted(result);
+        } catch (Exception e) {
+            log.error("확인 명령 실행 실패: intent={}", commandLog.getInterpretedIntent(), e);
+            commandLog.markFailed(e.getMessage());
+            result = "명령 실행 중 오류가 발생했습니다: " + e.getMessage();
+        }
+
+        return new NlpCommandResponse(
+                commandLog.getId(),
+                commandLog.getInterpretedIntent(),
+                "명령이 실행되었습니다.",
+                result,
+                commandLog.getRiskLevel(),
+                false,
+                commandLog.getSession() != null ? commandLog.getSession().getSessionToken() : null
+        );
+    }
+
+    public Page<CommandLogResponse> getHistory(Long userId, Pageable pageable) {
+        return commandLogRepository.findByUserId(userId, pageable)
+                .map(CommandLogResponse::from);
+    }
+
+    private ConversationSession getOrCreateSession(User user, String sessionId) {
+        if (sessionId != null && !sessionId.isBlank()) {
+            return sessionRepository.findBySessionTokenAndActiveTrue(sessionId)
+                    .orElseGet(() -> sessionRepository.save(new ConversationSession(user)));
+        }
+        return sessionRepository.save(new ConversationSession(user));
+    }
+
+    private String serializeArgs(ParsedIntent parsedIntent) {
+        try {
+            return objectMapper.writeValueAsString(parsedIntent.args());
+        } catch (JsonProcessingException e) {
+            log.warn("Intent 인자 직렬화 실패", e);
+            return "{}";
+        }
+    }
+
+    private ParsedIntent deserializeParsedIntent(CommandLog commandLog) {
+        try {
+            var args = objectMapper.readValue(
+                    commandLog.getIntentArgs(),
+                    new com.fasterxml.jackson.core.type.TypeReference<java.util.Map<String, Object>>() {}
+            );
+            return new ParsedIntent(commandLog.getInterpretedIntent(), args, 1.0, "");
+        } catch (JsonProcessingException e) {
+            throw new AiProcessingException(ErrorCode.AI_PARSE_ERROR,
+                    "저장된 Intent 인자 복원 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/klepaas/backend/global/exception/ErrorCode.java
+++ b/src/main/java/klepaas/backend/global/exception/ErrorCode.java
@@ -31,7 +31,13 @@ public enum ErrorCode {
     BUILD_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, "INFRA_003", "빌드 시간이 초과되었습니다"),
     BUILD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "INFRA_004", "빌드에 실패했습니다"),
     DEPLOY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "INFRA_005", "배포에 실패했습니다"),
-    NCP_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INFRA_006", "NCP API 호출에 실패했습니다");
+    NCP_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INFRA_006", "NCP API 호출에 실패했습니다"),
+
+    // AI / NLP
+    AI_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI_001", "AI API 호출에 실패했습니다"),
+    AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI_002", "AI 응답 파싱에 실패했습니다"),
+    COMMAND_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "AI_003", "명령 기록을 찾을 수 없습니다"),
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "AI_004", "세션을 찾을 수 없습니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,3 +54,9 @@ deployment:
     poll-initial-interval: 10000
     poll-max-interval: 60000
     build-timeout: 1800000
+
+gemini:
+  api:
+    base-url: https://generativelanguage.googleapis.com
+    key: ${GEMINI_API_KEY:your-gemini-api-key}
+    model: ${GEMINI_MODEL:gemini-2.0-flash}

--- a/src/main/resources/prompts/system-prompt.txt
+++ b/src/main/resources/prompts/system-prompt.txt
@@ -1,0 +1,41 @@
+당신은 클라우드 배포 플랫폼(KLEPaaS)의 AI 어시스턴트입니다.
+사용자의 자연어 명령을 분석하여 적절한 Intent로 분류하고, 필요한 인자를 추출합니다.
+
+## 사용 가능한 Intent
+
+| Intent | 설명 | 필요한 인자 |
+|--------|------|------------|
+| DEPLOY | 새 배포 실행 | repository_id, branch_name(선택), commit_hash(선택) |
+| SCALE | 레플리카 수 조정 | deployment_id, replicas |
+| RESTART | 서비스 재시작 | deployment_id |
+| STATUS | 배포 상태 조회 | deployment_id |
+| LOGS | 배포 로그 조회 | deployment_id |
+| LIST_DEPLOYMENTS | 배포 이력 조회 | repository_id |
+| LIST_REPOSITORIES | 저장소 목록 조회 | (없음) |
+| OVERVIEW | 전체 프로젝트 현황 | (없음) |
+| HELP | 도움말 표시 | (없음) |
+| UNKNOWN | 인식 불가 | (없음) |
+
+## 응답 형식
+
+반드시 아래 JSON 형식으로만 응답하세요. 추가 설명이나 마크다운은 포함하지 마세요.
+
+```json
+{
+  "intent": "INTENT_NAME",
+  "args": {
+    "key": "value"
+  },
+  "confidence": 0.95,
+  "message": "사용자에게 보여줄 한국어 메시지"
+}
+```
+
+## 규칙
+
+1. 사용자 입력은 한국어 또는 영어일 수 있습니다.
+2. message 필드는 항상 한국어로 작성합니다.
+3. 인자 값이 명확하지 않으면 message에서 추가 정보를 요청하세요.
+4. confidence는 0.0~1.0 사이의 값으로, 의도 파악 확신도를 나타냅니다.
+5. 숫자 인자(deployment_id, repository_id, replicas 등)는 정수로 반환합니다.
+6. 의도를 파악할 수 없으면 UNKNOWN으로 분류하고 message에 안내 메시지를 포함합니다.

--- a/src/test/java/klepaas/backend/ai/client/GeminiClientTest.java
+++ b/src/test/java/klepaas/backend/ai/client/GeminiClientTest.java
@@ -1,0 +1,72 @@
+package klepaas.backend.ai.client;
+
+import klepaas.backend.ai.client.dto.GeminiRequest;
+import klepaas.backend.ai.client.dto.GeminiResponse;
+import klepaas.backend.ai.exception.AiProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GeminiClientTest {
+
+    @Mock private RestClient restClient;
+    @Mock private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+    @Mock private RestClient.RequestBodySpec requestBodySpec;
+    @Mock private RestClient.ResponseSpec responseSpec;
+
+    private GeminiClient geminiClient;
+
+    @BeforeEach
+    void setUp() {
+        geminiClient = new GeminiClient(restClient, "test-api-key", "gemini-2.0-flash");
+    }
+
+    @Test
+    @DisplayName("Gemini API 호출 성공")
+    void generateSuccess() {
+        var expectedResponse = new GeminiResponse(List.of(
+                new GeminiResponse.Candidate(
+                        new GeminiResponse.Content(
+                                List.of(new GeminiResponse.Part("{\"intent\":\"HELP\"}")),
+                                "model"
+                        )
+                )
+        ));
+
+        given(restClient.post()).willReturn(requestBodyUriSpec);
+        given(requestBodyUriSpec.uri(anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.body(any(GeminiRequest.class))).willReturn(requestBodySpec);
+        given(requestBodySpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.onStatus(any(), any())).willReturn(responseSpec);
+        given(responseSpec.body(GeminiResponse.class)).willReturn(expectedResponse);
+
+        GeminiRequest request = GeminiRequest.of("system prompt", "도움말");
+        GeminiResponse response = geminiClient.generate(request);
+
+        assertThat(response.extractText()).contains("HELP");
+    }
+
+    @Test
+    @DisplayName("GeminiResponse.extractText - 빈 응답")
+    void extractTextEmptyResponse() {
+        var emptyResponse = new GeminiResponse(List.of());
+        assertThat(emptyResponse.extractText()).isEmpty();
+
+        var nullResponse = new GeminiResponse(null);
+        assertThat(nullResponse.extractText()).isEmpty();
+    }
+}

--- a/src/test/java/klepaas/backend/ai/controller/NlpControllerTest.java
+++ b/src/test/java/klepaas/backend/ai/controller/NlpControllerTest.java
@@ -1,0 +1,137 @@
+package klepaas.backend.ai.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import klepaas.backend.ai.dto.NlpCommandResponse;
+import klepaas.backend.ai.entity.Intent;
+import klepaas.backend.ai.entity.RiskLevel;
+import klepaas.backend.ai.service.NlpCommandService;
+import klepaas.backend.auth.config.CustomUserDetails;
+import klepaas.backend.auth.config.SecurityConfig;
+import klepaas.backend.auth.jwt.JwtAuthenticationFilter;
+import klepaas.backend.auth.jwt.JwtTokenProvider;
+import klepaas.backend.user.entity.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NlpController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class NlpControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @MockitoBean
+    private NlpCommandService nlpCommandService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CustomUserDetails testUser = new CustomUserDetails(1L, "test@test.com", Role.USER);
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/nlp/command - 명령 처리 성공")
+    void processCommand() throws Exception {
+        var response = new NlpCommandResponse(
+                1L, Intent.HELP, "도움말입니다", "도움말 결과",
+                RiskLevel.LOW, false, "session-token");
+
+        given(nlpCommandService.processCommand(eq(1L), any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/nlp/command")
+                        .with(user(testUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("command", "도움말"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.intent").value("HELP"))
+                .andExpect(jsonPath("$.data.risk_level").value("LOW"))
+                .andExpect(jsonPath("$.data.requires_confirmation").value(false));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/nlp/command - 위험 명령은 확인 필요 응답")
+    void processHighRiskCommand() throws Exception {
+        var response = new NlpCommandResponse(
+                1L, Intent.DEPLOY, "배포를 실행합니다", null,
+                RiskLevel.HIGH, true, "session-token");
+
+        given(nlpCommandService.processCommand(eq(1L), any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/nlp/command")
+                        .with(user(testUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("command", "배포해줘"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.requires_confirmation").value(true))
+                .andExpect(jsonPath("$.data.risk_level").value("HIGH"));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/nlp/confirm - 확인 성공")
+    void confirmCommand() throws Exception {
+        var response = new NlpCommandResponse(
+                1L, Intent.DEPLOY, "배포가 실행되었습니다", "배포 시작됨",
+                RiskLevel.HIGH, false, "session-token");
+
+        given(nlpCommandService.confirmCommand(eq(1L), any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/nlp/confirm")
+                        .with(user(testUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "command_log_id", 1,
+                                "confirmed", true,
+                                "git_token", "ghp_token"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.result").value("배포 시작됨"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 요청 시 401")
+    void unauthorizedWithoutToken() throws Exception {
+        mockMvc.perform(post("/api/v1/nlp/command")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"command\": \"도움말\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/nlp/history - 인증 후 조회 성공")
+    void getHistory() throws Exception {
+        mockMvc.perform(get("/api/v1/nlp/history")
+                        .with(user(testUser)))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/klepaas/backend/ai/service/ActionDispatcherTest.java
+++ b/src/test/java/klepaas/backend/ai/service/ActionDispatcherTest.java
@@ -1,0 +1,116 @@
+package klepaas.backend.ai.service;
+
+import klepaas.backend.ai.dto.ParsedIntent;
+import klepaas.backend.ai.entity.Intent;
+import klepaas.backend.ai.entity.RiskLevel;
+import klepaas.backend.deployment.dto.DeploymentStatusResponse;
+import klepaas.backend.deployment.dto.RepositoryResponse;
+import klepaas.backend.deployment.entity.CloudVendor;
+import klepaas.backend.deployment.entity.DeploymentStatus;
+import klepaas.backend.deployment.service.DeploymentService;
+import klepaas.backend.deployment.service.RepositoryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ActionDispatcherTest {
+
+    @InjectMocks
+    private ActionDispatcher actionDispatcher;
+
+    @Mock
+    private DeploymentService deploymentService;
+
+    @Mock
+    private RepositoryService repositoryService;
+
+    @Test
+    @DisplayName("DEPLOY는 HIGH 리스크")
+    void classifyDeployAsHigh() {
+        assertThat(actionDispatcher.classifyRisk(Intent.DEPLOY)).isEqualTo(RiskLevel.HIGH);
+    }
+
+    @Test
+    @DisplayName("SCALE은 MEDIUM 리스크")
+    void classifyScaleAsMedium() {
+        assertThat(actionDispatcher.classifyRisk(Intent.SCALE)).isEqualTo(RiskLevel.MEDIUM);
+    }
+
+    @Test
+    @DisplayName("RESTART은 MEDIUM 리스크")
+    void classifyRestartAsMedium() {
+        assertThat(actionDispatcher.classifyRisk(Intent.RESTART)).isEqualTo(RiskLevel.MEDIUM);
+    }
+
+    @Test
+    @DisplayName("STATUS는 LOW 리스크")
+    void classifyStatusAsLow() {
+        assertThat(actionDispatcher.classifyRisk(Intent.STATUS)).isEqualTo(RiskLevel.LOW);
+    }
+
+    @Test
+    @DisplayName("HELP는 LOW 리스크")
+    void classifyHelpAsLow() {
+        assertThat(actionDispatcher.classifyRisk(Intent.HELP)).isEqualTo(RiskLevel.LOW);
+    }
+
+    @Test
+    @DisplayName("STATUS 디스패치 시 DeploymentService 호출")
+    void dispatchStatus() {
+        var parsedIntent = new ParsedIntent(Intent.STATUS, Map.of("deployment_id", 1), 0.9, "상태 확인");
+        var statusResponse = new DeploymentStatusResponse(1L, DeploymentStatus.SUCCESS, null);
+        given(deploymentService.getDeploymentStatus(1L)).willReturn(statusResponse);
+
+        String result = actionDispatcher.dispatch(parsedIntent, 1L, null);
+
+        assertThat(result).contains("SUCCESS");
+        verify(deploymentService).getDeploymentStatus(1L);
+    }
+
+    @Test
+    @DisplayName("SCALE 디스패치 시 DeploymentService.scaleDeployment 호출")
+    void dispatchScale() {
+        var parsedIntent = new ParsedIntent(Intent.SCALE, Map.of("deployment_id", 1, "replicas", 3), 0.9, "스케일링");
+
+        String result = actionDispatcher.dispatch(parsedIntent, 1L, null);
+
+        assertThat(result).contains("3개 레플리카");
+        verify(deploymentService).scaleDeployment(eq(1L), any());
+    }
+
+    @Test
+    @DisplayName("LIST_REPOSITORIES 디스패치 시 RepositoryService 호출")
+    void dispatchListRepositories() {
+        var repo = new RepositoryResponse(1L, "owner", "repo", "https://github.com/owner/repo",
+                CloudVendor.NCP, 1L, LocalDateTime.now(), LocalDateTime.now());
+        given(repositoryService.getRepositories(1L)).willReturn(List.of(repo));
+
+        var parsedIntent = new ParsedIntent(Intent.LIST_REPOSITORIES, Map.of(), 0.9, "저장소 목록");
+        String result = actionDispatcher.dispatch(parsedIntent, 1L, null);
+
+        assertThat(result).contains("owner/repo");
+    }
+
+    @Test
+    @DisplayName("HELP 디스패치 시 도움말 반환")
+    void dispatchHelp() {
+        var parsedIntent = new ParsedIntent(Intent.HELP, Map.of(), 1.0, "도움말");
+        String result = actionDispatcher.dispatch(parsedIntent, 1L, null);
+
+        assertThat(result).contains("사용 가능한 명령어");
+    }
+}

--- a/src/test/java/klepaas/backend/ai/service/IntentParserTest.java
+++ b/src/test/java/klepaas/backend/ai/service/IntentParserTest.java
@@ -1,0 +1,92 @@
+package klepaas.backend.ai.service;
+
+import klepaas.backend.ai.dto.ParsedIntent;
+import klepaas.backend.ai.entity.Intent;
+import klepaas.backend.ai.exception.AiProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IntentParserTest {
+
+    private IntentParser intentParser;
+
+    @BeforeEach
+    void setUp() {
+        intentParser = new IntentParser();
+    }
+
+    @Test
+    @DisplayName("JSON 직접 응답 파싱 성공")
+    void parseDirectJson() {
+        String response = """
+                {"intent": "SCALE", "args": {"deployment_id": 1, "replicas": 3}, "confidence": 0.95, "message": "스케일링합니다"}
+                """;
+
+        ParsedIntent result = intentParser.parse(response);
+
+        assertThat(result.intent()).isEqualTo(Intent.SCALE);
+        assertThat(result.args()).containsEntry("deployment_id", 1);
+        assertThat(result.args()).containsEntry("replicas", 3);
+        assertThat(result.confidence()).isEqualTo(0.95);
+        assertThat(result.message()).isEqualTo("스케일링합니다");
+    }
+
+    @Test
+    @DisplayName("마크다운 코드블록 내 JSON 파싱 성공")
+    void parseMarkdownCodeBlock() {
+        String response = """
+                ```json
+                {"intent": "DEPLOY", "args": {"repository_id": 5, "branch_name": "main"}, "confidence": 0.9, "message": "배포합니다"}
+                ```
+                """;
+
+        ParsedIntent result = intentParser.parse(response);
+
+        assertThat(result.intent()).isEqualTo(Intent.DEPLOY);
+        assertThat(result.args()).containsEntry("repository_id", 5);
+    }
+
+    @Test
+    @DisplayName("코드블록 없는 마크다운 파싱 성공")
+    void parseCodeBlockWithoutJsonLabel() {
+        String response = """
+                ```
+                {"intent": "HELP", "args": {}, "confidence": 1.0, "message": "도움말"}
+                ```
+                """;
+
+        ParsedIntent result = intentParser.parse(response);
+
+        assertThat(result.intent()).isEqualTo(Intent.HELP);
+    }
+
+    @Test
+    @DisplayName("알 수 없는 Intent는 UNKNOWN으로 처리")
+    void parseUnknownIntent() {
+        String response = """
+                {"intent": "INVALID_INTENT", "args": {}, "confidence": 0.3, "message": "알 수 없음"}
+                """;
+
+        ParsedIntent result = intentParser.parse(response);
+
+        assertThat(result.intent()).isEqualTo(Intent.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("빈 응답은 예외 발생")
+    void parseEmptyResponse() {
+        assertThatThrownBy(() -> intentParser.parse(""))
+                .isInstanceOf(AiProcessingException.class);
+    }
+
+    @Test
+    @DisplayName("JSON이 아닌 응답은 예외 발생")
+    void parseNonJsonResponse() {
+        assertThatThrownBy(() -> intentParser.parse("이것은 JSON이 아닙니다"))
+                .isInstanceOf(AiProcessingException.class);
+    }
+}

--- a/src/test/java/klepaas/backend/ai/service/NlpCommandServiceTest.java
+++ b/src/test/java/klepaas/backend/ai/service/NlpCommandServiceTest.java
@@ -1,0 +1,161 @@
+package klepaas.backend.ai.service;
+
+import klepaas.backend.ai.client.GeminiClient;
+import klepaas.backend.ai.client.dto.GeminiResponse;
+import klepaas.backend.ai.dto.NlpCommandRequest;
+import klepaas.backend.ai.dto.NlpCommandResponse;
+import klepaas.backend.ai.dto.NlpConfirmRequest;
+import klepaas.backend.ai.entity.*;
+import klepaas.backend.ai.repository.CommandLogRepository;
+import klepaas.backend.ai.repository.ConversationSessionRepository;
+import klepaas.backend.user.entity.Role;
+import klepaas.backend.user.entity.User;
+import klepaas.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ByteArrayResource;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NlpCommandServiceTest {
+
+    @Mock private GeminiClient geminiClient;
+    @Mock private IntentParser intentParser;
+    @Mock private ActionDispatcher actionDispatcher;
+    @Mock private CommandLogRepository commandLogRepository;
+    @Mock private ConversationSessionRepository sessionRepository;
+    @Mock private UserRepository userRepository;
+
+    private NlpCommandService nlpCommandService;
+    private User testUser;
+    private ConversationSession testSession;
+
+    @BeforeEach
+    void setUp() {
+        var systemPromptResource = new ByteArrayResource("테스트 시스템 프롬프트".getBytes());
+        nlpCommandService = new NlpCommandService(
+                geminiClient, intentParser, actionDispatcher,
+                commandLogRepository, sessionRepository, userRepository,
+                systemPromptResource
+        );
+
+        testUser = User.builder()
+                .name("testuser")
+                .email("test@test.com")
+                .role(Role.USER)
+                .providerId("12345")
+                .build();
+
+        testSession = new ConversationSession(testUser);
+    }
+
+    @Test
+    @DisplayName("LOW 리스크 명령은 즉시 실행")
+    void processLowRiskCommand() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(sessionRepository.save(any())).willReturn(testSession);
+        given(geminiClient.generate(any())).willReturn(mockGeminiResponse("test"));
+        given(intentParser.parse("test")).willReturn(
+                new klepaas.backend.ai.dto.ParsedIntent(Intent.HELP, java.util.Map.of(), 1.0, "도움말"));
+        given(actionDispatcher.classifyRisk(Intent.HELP)).willReturn(RiskLevel.LOW);
+        given(actionDispatcher.dispatch(any(), eq(1L), isNull())).willReturn("도움말 결과");
+        given(commandLogRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        NlpCommandResponse response = nlpCommandService.processCommand(1L,
+                new NlpCommandRequest("도움말", null));
+
+        assertThat(response.requiresConfirmation()).isFalse();
+        assertThat(response.result()).isEqualTo("도움말 결과");
+        assertThat(response.intent()).isEqualTo(Intent.HELP);
+    }
+
+    @Test
+    @DisplayName("HIGH 리스크 명령은 확인 대기")
+    void processHighRiskCommand() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+        given(sessionRepository.save(any())).willReturn(testSession);
+        given(geminiClient.generate(any())).willReturn(mockGeminiResponse("test"));
+        given(intentParser.parse("test")).willReturn(
+                new klepaas.backend.ai.dto.ParsedIntent(Intent.DEPLOY,
+                        java.util.Map.of("repository_id", 1, "branch_name", "main"), 0.95, "배포합니다"));
+        given(actionDispatcher.classifyRisk(Intent.DEPLOY)).willReturn(RiskLevel.HIGH);
+        given(commandLogRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        NlpCommandResponse response = nlpCommandService.processCommand(1L,
+                new NlpCommandRequest("프로젝트 배포해줘", null));
+
+        assertThat(response.requiresConfirmation()).isTrue();
+        assertThat(response.result()).isNull();
+        assertThat(response.riskLevel()).isEqualTo(RiskLevel.HIGH);
+        verify(actionDispatcher, never()).dispatch(any(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("확인 시 명령 실행")
+    void confirmCommandExecutes() {
+        CommandLog commandLog = CommandLog.builder()
+                .user(testUser)
+                .rawCommand("배포해줘")
+                .interpretedIntent(Intent.DEPLOY)
+                .intentArgs("{\"repository_id\":1,\"branch_name\":\"main\"}")
+                .riskLevel(RiskLevel.HIGH)
+                .requiresConfirmation(true)
+                .session(testSession)
+                .build();
+
+        given(commandLogRepository.findById(1L)).willReturn(Optional.of(commandLog));
+        given(actionDispatcher.dispatch(any(), eq(1L), eq("ghp_token")))
+                .willReturn("배포가 시작되었습니다");
+
+        NlpCommandResponse response = nlpCommandService.confirmCommand(1L,
+                new NlpConfirmRequest(1L, true, "ghp_token"));
+
+        assertThat(response.result()).isEqualTo("배포가 시작되었습니다");
+        verify(actionDispatcher).dispatch(any(), eq(1L), eq("ghp_token"));
+    }
+
+    @Test
+    @DisplayName("취소 시 명령 미실행")
+    void cancelCommandDoesNotExecute() {
+        CommandLog commandLog = CommandLog.builder()
+                .user(testUser)
+                .rawCommand("배포해줘")
+                .interpretedIntent(Intent.DEPLOY)
+                .intentArgs("{\"repository_id\":1}")
+                .riskLevel(RiskLevel.HIGH)
+                .requiresConfirmation(true)
+                .session(testSession)
+                .build();
+
+        given(commandLogRepository.findById(1L)).willReturn(Optional.of(commandLog));
+
+        NlpCommandResponse response = nlpCommandService.confirmCommand(1L,
+                new NlpConfirmRequest(1L, false, null));
+
+        assertThat(response.message()).contains("취소");
+        assertThat(response.result()).isNull();
+        verify(actionDispatcher, never()).dispatch(any(), anyLong(), any());
+    }
+
+    private GeminiResponse mockGeminiResponse(String text) {
+        return new GeminiResponse(List.of(
+                new GeminiResponse.Candidate(
+                        new GeminiResponse.Content(
+                                List.of(new GeminiResponse.Part(text)),
+                                "model"
+                        )
+                )
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
  - Gemini REST API를 연동한 자연어 명령 처리 파이프라인 구현
  - 사용자 입력 → Intent 파싱 → 리스크 분류 → 자동 실행/확인 대기 흐름
  - 기존 DeploymentService, RepositoryService와 ActionDispatcher를 통해 연동

  ## 주요 변경사항
  - 신규 파일 20개 (config, client, service, controller, entity, dto, repository, exception)
  - 테스트 파일 5개 추가 (62개 전체 통과)
  - CommandLog 엔티티 확장 (Intent enum, 리스크 레벨, 세션 등)
  - application.yaml에 Gemini API 설정 추가

  ## API 엔드포인트
  | Method | URL | 설명 |
  |--------|-----|------|
  | POST | /api/v1/nlp/command | 자연어 명령 처리 |
  | POST | /api/v1/nlp/confirm | 위험 명령 확인/취소 |
  | GET | /api/v1/nlp/history | 명령 이력 조회 |

  ## Test plan
  - [x] ./gradlew test 전체 통과 (62개)
  - [ ] Gemini API key 등록 후 Swagger UI에서 E2E 테스트