### PR TITLE
feat: Slack 배포 알림 추가

### DIFF
--- a/backend/src/main/java/klepaas/backend/deployment/service/DeploymentPipelineService.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/DeploymentPipelineService.java
@@ -9,6 +9,7 @@ import klepaas.backend.deployment.repository.DeploymentRepository;
 import klepaas.backend.deployment.repository.SourceRepositoryRepository;
 import klepaas.backend.global.exception.BusinessException;
 import klepaas.backend.global.exception.ErrorCode;
+import klepaas.backend.global.service.NotificationService;
 import klepaas.backend.infra.CloudInfraProvider;
 import klepaas.backend.infra.CloudInfraProviderFactory;
 import klepaas.backend.infra.dto.BuildResult;
@@ -33,6 +34,7 @@ public class DeploymentPipelineService {
     private final CloudInfraProviderFactory infraProviderFactory;
     private final KubernetesManifestGenerator k8sGenerator;
     private final GitHubInstallationTokenService installationTokenService;
+    private final NotificationService notificationService;
 
     @Value("${deployment.pipeline.poll-initial-interval:10000}")
     private long pollInitialInterval;
@@ -77,6 +79,7 @@ public class DeploymentPipelineService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     protected String executeUpload(Long deploymentId) {
         Deployment deployment = getDeployment(deploymentId);
+        notificationService.notifyDeploymentStarted(deployment);
         deployment.startUpload();
         deploymentRepository.save(deployment);
 
@@ -168,6 +171,7 @@ public class DeploymentPipelineService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     protected void markSuccess(Long deploymentId) {
         Deployment deployment = getDeployment(deploymentId);
+        notificationService.notifyDeploymentSuccess(deployment);
         deployment.completeSuccess();
         deploymentRepository.save(deployment);
     }
@@ -176,6 +180,7 @@ public class DeploymentPipelineService {
     protected void markFailed(Long deploymentId, String reason) {
         try {
             Deployment deployment = getDeployment(deploymentId);
+            notificationService.notifyDeploymentFailed(deployment, reason);
             deployment.fail(reason);
             deploymentRepository.save(deployment);
         } catch (Exception e) {

--- a/backend/src/main/java/klepaas/backend/global/service/SlackNotificationService.java
+++ b/backend/src/main/java/klepaas/backend/global/service/SlackNotificationService.java
@@ -1,0 +1,65 @@
+package klepaas.backend.global.service;
+
+import klepaas.backend.deployment.entity.Deployment;
+import klepaas.backend.deployment.entity.SourceRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Service
+public class SlackNotificationService implements NotificationService {
+
+    @Value("${slack.webhook.url}")
+    private String slackWebhookUrl;
+
+    private final RestClient restClient = RestClient.create();
+
+    @Override
+    public void notifyDeploymentStarted(Deployment deployment) {
+        String message = "🚀 배포 시작 - %s (브랜치: %s)"
+                .formatted(formatRepository(deployment), deployment.getBranchName());
+        sendMessage(message);
+    }
+
+    @Override
+    public void notifyDeploymentSuccess(Deployment deployment) {
+        String message = "✅ 배포 성공 - %s".formatted(formatRepository(deployment));
+        sendMessage(message);
+    }
+
+    @Override
+    public void notifyDeploymentFailed(Deployment deployment, String reason) {
+        String message = "❌ 배포 실패 - %s: %s"
+                .formatted(formatRepository(deployment), reason == null ? "알 수 없는 오류" : reason);
+        sendMessage(message);
+    }
+
+    private void sendMessage(String message) {
+        if (slackWebhookUrl == null || slackWebhookUrl.isBlank()) {
+            log.warn("Slack webhook URL is empty. Skip notification: {}", message);
+            return;
+        }
+
+        try {
+            restClient.post()
+                    .uri(slackWebhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new SlackWebhookRequest(message))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("Failed to send Slack notification: {}", e.getMessage());
+        }
+    }
+
+    private String formatRepository(Deployment deployment) {
+        SourceRepository repo = deployment.getSourceRepository();
+        return repo.getOwner() + "/" + repo.getRepoName();
+    }
+
+    private record SlackWebhookRequest(String text) {
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -13,11 +13,22 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
     defer-datasource-initialization: true
   h2:
     console:
       enabled: true
+
+logging:
+  level:
+    root: INFO
+    klepaas.backend: DEBUG
+    org.hibernate.SQL: WARN
+    org.hibernate.type.descriptor.sql: WARN
+    org.springframework.web: INFO
 
 app:
   version: 0.0.1-SNAPSHOT
@@ -60,6 +71,10 @@ deployment:
     poll-initial-interval: 10000
     poll-max-interval: 60000
     build-timeout: 1800000
+
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL:}
 
 gemini:
   api:


### PR DESCRIPTION
  ## 관련 이슈
  closes #17 

  ## 변경 사항
  - `SlackNotificationService`: NotificationService 구현체. RestClient로 Slack Webhook POST
  - 메시지 포맷
    - 시작: 🚀 배포 시작 - owner/repo (브랜치: branch)
    - 성공: ✅ 배포 성공 - owner/repo
    - 실패: ❌ 배포 실패 - owner/repo: reason
  - Webhook URL 비어 있으면 warn 로그만 남기고 skip
  - `DeploymentPipelineService`: markSuccess/markFailed/@Transactional 블록 안에서 호출

  ## 특이사항
  - SLACK_WEBHOOK_URL 환경변수 미설정 시 알림 비활성화 (배포 흐름 영향 없음)