### PR TITLE
feat: 배포 이미지 태그를 commit SHA 기반으로 변경

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -145,7 +145,7 @@ initContainer(amazon/aws-cli)
 
 kaniko
   → --context=dir:///workspace
-  → --destination={NCR_ENDPOINT}/{owner}-{repo}:latest
+  → --destination={NCR_ENDPOINT}/{owner}-{repo}:{shortSha}
 ```
 
 ### AI 모듈 — Java 내장 Gemini 직접 호출

--- a/backend/src/main/java/klepaas/backend/deployment/entity/Deployment.java
+++ b/backend/src/main/java/klepaas/backend/deployment/entity/Deployment.java
@@ -83,6 +83,10 @@ public class Deployment extends BaseTimeEntity {
         this.imageUri = imageUri;
     }
 
+    public void updateCommitHash(String commitHash) {
+        this.commitHash = commitHash;
+    }
+
     // 배포 성공
     public void completeSuccess() {
         this.status = DeploymentStatus.SUCCESS;

--- a/backend/src/main/java/klepaas/backend/infra/dto/BuildResult.java
+++ b/backend/src/main/java/klepaas/backend/infra/dto/BuildResult.java
@@ -3,5 +3,5 @@ package klepaas.backend.infra.dto;
 public record BuildResult(
         String externalBuildId,
         String trackingUrl,   // projectId
-        String imageUri       // 빌드 트리거 시점에 계산: {registryEndpoint}/{owner}-{repoName}:latest
+        String imageUri       // 빌드 트리거 시점에 계산: {registryEndpoint}/{owner}-{repoName}:{shortSha}
 ) {}

--- a/backend/src/main/java/klepaas/backend/infra/service/NcpInfraService.java
+++ b/backend/src/main/java/klepaas/backend/infra/service/NcpInfraService.java
@@ -12,6 +12,7 @@ import klepaas.backend.global.exception.ErrorCode;
 import klepaas.backend.infra.CloudInfraProvider;
 import klepaas.backend.infra.dto.BuildResult;
 import klepaas.backend.infra.dto.BuildStatusResult;
+import klepaas.backend.infra.util.ImageTagGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -75,6 +76,8 @@ public class NcpInfraService implements CloudInfraProvider {
         String storageKey = "builds/" + deployment.getId() + "/source.zip";
 
         try {
+            resolveCommitHashIfNeeded(gitToken, deployment);
+
             // Step 1: GitHub API 호출 → 302 redirect URL 획득 (auth 필요)
             String apiUrl = "https://api.github.com/repos/" + repo.getOwner() + "/" +
                     repo.getRepoName() + "/zipball/" + deployment.getCommitHash();
@@ -135,9 +138,7 @@ public class NcpInfraService implements CloudInfraProvider {
     public BuildResult triggerBuild(String storageKey, Deployment deployment) {
         SourceRepository repo = deployment.getSourceRepository();
         String imageName = repo.getOwner() + "-" + repo.getRepoName();
-        String commitHash = deployment.getCommitHash();
-        String shortSha = commitHash.length() >= 7 ? commitHash.substring(0, 7) : commitHash;
-        String imageUri = registryEndpoint + "/" + imageName + ":" + shortSha;
+        String imageUri = ImageTagGenerator.buildImageUri(registryEndpoint, imageName, deployment.getCommitHash());
         String jobName = "klepaas-build-" + deployment.getId();
 
         try {
@@ -279,7 +280,7 @@ public class NcpInfraService implements CloudInfraProvider {
     }
 
     private Job buildKanikoJob(String jobName, String storageKey, String imageUri, Deployment deployment) {
-        String shortSha = deployment.getCommitHash().substring(0, Math.min(7, deployment.getCommitHash().length()));
+        String shortSha = ImageTagGenerator.toShortSha(deployment.getCommitHash());
 
         Map<String, String> labels = Map.of(
                 "app.kubernetes.io/managed-by", "klepaas",
@@ -369,6 +370,50 @@ public class NcpInfraService implements CloudInfraProvider {
                     .endTemplate()
                 .endSpec()
                 .build();
+    }
+
+    private void resolveCommitHashIfNeeded(String gitToken, Deployment deployment) throws IOException, InterruptedException {
+        if (!"HEAD".equalsIgnoreCase(deployment.getCommitHash())) {
+            return;
+        }
+
+        SourceRepository repo = deployment.getSourceRepository();
+        String apiUrl = "https://api.github.com/repos/" + repo.getOwner() + "/" +
+                repo.getRepoName() + "/commits/" + deployment.getBranchName();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(apiUrl))
+                .header("Authorization", "Bearer " + gitToken)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .GET()
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new BusinessException(ErrorCode.SOURCE_UPLOAD_FAILED,
+                    "브랜치 HEAD 커밋 조회 실패: HTTP " + response.statusCode());
+        }
+
+        String resolvedSha = extractCommitSha(response.body());
+        deployment.updateCommitHash(resolvedSha);
+        log.info("Resolved HEAD to commit SHA: deploymentId={}, branch={}, sha={}",
+                deployment.getId(), deployment.getBranchName(), resolvedSha);
+    }
+
+    private String extractCommitSha(String body) {
+        int shaKeyIndex = body.indexOf("\"sha\"");
+        if (shaKeyIndex < 0) {
+            throw new BusinessException(ErrorCode.SOURCE_UPLOAD_FAILED, "GitHub 커밋 SHA 응답 파싱 실패");
+        }
+
+        int colonIndex = body.indexOf(':', shaKeyIndex);
+        int firstQuote = body.indexOf('"', colonIndex + 1);
+        int secondQuote = body.indexOf('"', firstQuote + 1);
+        if (colonIndex < 0 || firstQuote < 0 || secondQuote < 0) {
+            throw new BusinessException(ErrorCode.SOURCE_UPLOAD_FAILED, "GitHub 커밋 SHA 응답 파싱 실패");
+        }
+        return body.substring(firstQuote + 1, secondQuote);
     }
 
     /**

--- a/backend/src/main/java/klepaas/backend/infra/util/ImageTagGenerator.java
+++ b/backend/src/main/java/klepaas/backend/infra/util/ImageTagGenerator.java
@@ -1,0 +1,26 @@
+package klepaas.backend.infra.util;
+
+public final class ImageTagGenerator {
+
+    private static final int SHORT_SHA_LENGTH = 7;
+
+    private ImageTagGenerator() {
+    }
+
+    public static String toShortSha(String commitHash) {
+        if (commitHash == null || commitHash.isBlank()) {
+            throw new IllegalArgumentException("commitHash must not be blank");
+        }
+        return commitHash.substring(0, Math.min(SHORT_SHA_LENGTH, commitHash.length()));
+    }
+
+    public static String buildImageUri(String registryEndpoint, String imageName, String commitHash) {
+        if (registryEndpoint == null || registryEndpoint.isBlank()) {
+            throw new IllegalArgumentException("registryEndpoint must not be blank");
+        }
+        if (imageName == null || imageName.isBlank()) {
+            throw new IllegalArgumentException("imageName must not be blank");
+        }
+        return registryEndpoint + "/" + imageName + ":" + toShortSha(commitHash);
+    }
+}

--- a/backend/src/test/java/klepaas/backend/ai/controller/NlpControllerTest.java
+++ b/backend/src/test/java/klepaas/backend/ai/controller/NlpControllerTest.java
@@ -9,6 +9,7 @@ import klepaas.backend.auth.config.CustomUserDetails;
 import klepaas.backend.auth.config.SecurityConfig;
 import klepaas.backend.auth.jwt.JwtAuthenticationFilter;
 import klepaas.backend.auth.jwt.JwtTokenProvider;
+import klepaas.backend.auth.token.service.CliAccessTokenService;
 import klepaas.backend.user.entity.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -48,6 +51,9 @@ class NlpControllerTest {
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CliAccessTokenService cliAccessTokenService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final CustomUserDetails testUser = new CustomUserDetails(1L, "test@test.com", Role.USER);
@@ -129,6 +135,8 @@ class NlpControllerTest {
     @Test
     @DisplayName("GET /api/v1/nlp/history - 인증 후 조회 성공")
     void getHistory() throws Exception {
+        given(nlpCommandService.getHistory(eq(1L), any())).willReturn(Page.empty());
+
         mockMvc.perform(get("/api/v1/nlp/history")
                         .with(user(testUser)))
                 .andExpect(status().isOk());

--- a/backend/src/test/java/klepaas/backend/ai/service/ActionDispatcherTest.java
+++ b/backend/src/test/java/klepaas/backend/ai/service/ActionDispatcherTest.java
@@ -1,14 +1,20 @@
 package klepaas.backend.ai.service;
 
 import klepaas.backend.ai.dto.ParsedIntent;
+import klepaas.backend.ai.dto.FormattedResponseDto;
 import klepaas.backend.ai.entity.Intent;
 import klepaas.backend.ai.entity.RiskLevel;
 import klepaas.backend.deployment.dto.DeploymentStatusResponse;
-import klepaas.backend.deployment.dto.RepositoryResponse;
+import klepaas.backend.ai.service.KubectlService;
+import klepaas.backend.deployment.repository.DeploymentRepository;
+import klepaas.backend.deployment.repository.SourceRepositoryRepository;
 import klepaas.backend.deployment.entity.CloudVendor;
 import klepaas.backend.deployment.entity.DeploymentStatus;
 import klepaas.backend.deployment.service.DeploymentService;
-import klepaas.backend.deployment.service.RepositoryService;
+import klepaas.backend.deployment.entity.Deployment;
+import klepaas.backend.deployment.entity.SourceRepository;
+import klepaas.backend.user.entity.Role;
+import klepaas.backend.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,9 +22,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,7 +42,13 @@ class ActionDispatcherTest {
     private DeploymentService deploymentService;
 
     @Mock
-    private RepositoryService repositoryService;
+    private KubectlService kubectlService;
+
+    @Mock
+    private DeploymentRepository deploymentRepository;
+
+    @Mock
+    private SourceRepositoryRepository sourceRepositoryRepository;
 
     @Test
     @DisplayName("DEPLOY는 HIGH 리스크")
@@ -75,9 +87,9 @@ class ActionDispatcherTest {
         var statusResponse = new DeploymentStatusResponse(1L, DeploymentStatus.SUCCESS, null);
         given(deploymentService.getDeploymentStatus(1L)).willReturn(statusResponse);
 
-        String result = actionDispatcher.dispatch(parsedIntent, 1L);
+        FormattedResponseDto result = (FormattedResponseDto) actionDispatcher.dispatch(parsedIntent, 1L);
 
-        assertThat(result).contains("SUCCESS");
+        assertThat(result.message()).contains("SUCCESS");
         verify(deploymentService).getDeploymentStatus(1L);
     }
 
@@ -86,31 +98,50 @@ class ActionDispatcherTest {
     void dispatchScale() {
         var parsedIntent = new ParsedIntent(Intent.SCALE, Map.of("deployment_id", 1, "replicas", 3), 0.9, "스케일링");
 
-        String result = actionDispatcher.dispatch(parsedIntent, 1L);
+        User user = User.builder()
+                .email("test@test.com")
+                .name("tester")
+                .role(Role.USER)
+                .providerId("123")
+                .build();
+        SourceRepository repository = SourceRepository.builder()
+                .user(user)
+                .owner("owner")
+                .repoName("repo")
+                .gitUrl("https://github.com/owner/repo")
+                .cloudVendor(CloudVendor.NCP)
+                .build();
+        Deployment deployment = Deployment.builder()
+                .sourceRepository(repository)
+                .branchName("main")
+                .commitHash("abc1234")
+                .build();
+        given(deploymentRepository.findById(1L)).willReturn(Optional.of(deployment));
 
-        assertThat(result).contains("3개 레플리카");
-        verify(deploymentService).scaleDeployment(eq(1L), any());
+        FormattedResponseDto result = (FormattedResponseDto) actionDispatcher.dispatch(parsedIntent, 1L);
+
+        assertThat(result.message()).contains("3개 레플리카");
+        verify(deploymentService).scaleDeployment(eq(1L), any(), eq("NLP"));
     }
 
     @Test
-    @DisplayName("LIST_REPOSITORIES 디스패치 시 RepositoryService 호출")
+    @DisplayName("LIST_REPOSITORIES 디스패치 시 안내 메시지 반환")
     void dispatchListRepositories() {
-        var repo = new RepositoryResponse(1L, "owner", "repo", "https://github.com/owner/repo",
-                CloudVendor.NCP, 1L, LocalDateTime.now(), LocalDateTime.now());
-        given(repositoryService.getRepositories(1L)).willReturn(List.of(repo));
-
         var parsedIntent = new ParsedIntent(Intent.LIST_REPOSITORIES, Map.of(), 0.9, "저장소 목록");
-        String result = actionDispatcher.dispatch(parsedIntent, 1L);
+        FormattedResponseDto result = (FormattedResponseDto) actionDispatcher.dispatch(parsedIntent, 1L);
 
-        assertThat(result).contains("owner/repo");
+        assertThat(result.message()).contains("저장소 목록");
     }
 
     @Test
     @DisplayName("HELP 디스패치 시 도움말 반환")
     void dispatchHelp() {
         var parsedIntent = new ParsedIntent(Intent.HELP, Map.of(), 1.0, "도움말");
-        String result = actionDispatcher.dispatch(parsedIntent, 1L);
+        given(kubectlService.listCommands()).willReturn(
+                FormattedResponseDto.of("list_commands", "사용 가능한 명령어 목록입니다.", "명령어", Map.of(), null)
+        );
+        FormattedResponseDto result = (FormattedResponseDto) actionDispatcher.dispatch(parsedIntent, 1L);
 
-        assertThat(result).contains("사용 가능한 명령어");
+        assertThat(result.message()).contains("사용 가능한 명령어");
     }
 }

--- a/backend/src/test/java/klepaas/backend/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/klepaas/backend/auth/controller/AuthControllerTest.java
@@ -5,6 +5,7 @@ import klepaas.backend.auth.config.SecurityConfig;
 import klepaas.backend.auth.dto.TokenResponse;
 import klepaas.backend.auth.jwt.JwtAuthenticationFilter;
 import klepaas.backend.auth.jwt.JwtTokenProvider;
+import klepaas.backend.auth.token.service.CliAccessTokenService;
 import klepaas.backend.auth.service.AuthService;
 import klepaas.backend.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +22,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -46,6 +49,9 @@ class AuthControllerTest {
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
+    @MockitoBean
+    private CliAccessTokenService cliAccessTokenService;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
@@ -59,7 +65,7 @@ class AuthControllerTest {
     @Test
     @DisplayName("GET /api/v1/auth/oauth2/url/github - OAuth URL 조회 (public)")
     void getOAuthUrl() throws Exception {
-        given(authService.getOAuthUrl("github"))
+        given(authService.getOAuthUrl("github", null, null))
                 .willReturn("https://github.com/login/oauth/authorize?client_id=test");
 
         mockMvc.perform(get("/api/v1/auth/oauth2/url/github"))
@@ -71,7 +77,7 @@ class AuthControllerTest {
     @DisplayName("POST /api/v1/auth/oauth2/login - OAuth 로그인 성공 (public)")
     void login() throws Exception {
         var tokenResponse = new TokenResponse("access_token_123", "refresh_token_456");
-        given(authService.login("valid_code")).willReturn(tokenResponse);
+        given(authService.login(eq("valid_code"), any())).willReturn(tokenResponse);
 
         mockMvc.perform(post("/api/v1/auth/oauth2/login")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/klepaas/backend/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/auth/service/AuthServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,9 +59,10 @@ class AuthServiceTest {
         @Test
         @DisplayName("성공: GitHub OAuth URL 반환")
         void successGitHub() {
-            given(gitHubOAuthClient.getAuthorizationUrl()).willReturn("https://github.com/login/oauth/authorize?client_id=test");
+            given(gitHubOAuthClient.getAuthorizationUrl(isNull(), isNull()))
+                    .willReturn("https://github.com/login/oauth/authorize?client_id=test");
 
-            String url = authService.getOAuthUrl("github");
+            String url = authService.getOAuthUrl("github", null, null);
 
             assertThat(url).contains("github.com/login/oauth/authorize");
         }
@@ -68,7 +70,7 @@ class AuthServiceTest {
         @Test
         @DisplayName("실패: 지원하지 않는 프로바이더")
         void failUnsupported() {
-            assertThatThrownBy(() -> authService.getOAuthUrl("google"))
+            assertThatThrownBy(() -> authService.getOAuthUrl("google", null, null))
                     .isInstanceOf(InvalidRequestException.class);
         }
     }
@@ -84,12 +86,12 @@ class AuthServiceTest {
             var githubUser = new GitHubUserResponse(12345L, "tester", "test@github.com", "tester");
             var jwtTokens = new TokenResponse("access_token", "refresh_token");
 
-            given(gitHubOAuthClient.exchangeCode("valid_code")).willReturn(tokenResponse);
+            given(gitHubOAuthClient.exchangeCode("valid_code", null)).willReturn(tokenResponse);
             given(gitHubOAuthClient.getUserInfo("ghp_token123")).willReturn(githubUser);
             given(userRepository.findByProviderId("12345")).willReturn(Optional.of(testUser));
             given(jwtTokenProvider.createTokens(any(), any(), any())).willReturn(jwtTokens);
 
-            TokenResponse result = authService.login("valid_code");
+            TokenResponse result = authService.login("valid_code", null);
 
             assertThat(result.accessToken()).isEqualTo("access_token");
             assertThat(result.refreshToken()).isEqualTo("refresh_token");
@@ -102,13 +104,13 @@ class AuthServiceTest {
             var githubUser = new GitHubUserResponse(99999L, "newuser", "new@github.com", "New User");
             var jwtTokens = new TokenResponse("access_token", "refresh_token");
 
-            given(gitHubOAuthClient.exchangeCode("valid_code")).willReturn(tokenResponse);
+            given(gitHubOAuthClient.exchangeCode("valid_code", null)).willReturn(tokenResponse);
             given(gitHubOAuthClient.getUserInfo("ghp_token123")).willReturn(githubUser);
             given(userRepository.findByProviderId("99999")).willReturn(Optional.empty());
             given(userRepository.save(any(User.class))).willReturn(testUser);
             given(jwtTokenProvider.createTokens(any(), any(), any())).willReturn(jwtTokens);
 
-            TokenResponse result = authService.login("valid_code");
+            TokenResponse result = authService.login("valid_code", null);
 
             assertThat(result.accessToken()).isEqualTo("access_token");
         }
@@ -116,9 +118,9 @@ class AuthServiceTest {
         @Test
         @DisplayName("실패: 유효하지 않은 인증 코드")
         void failInvalidCode() {
-            given(gitHubOAuthClient.exchangeCode("invalid_code")).willReturn(null);
+            given(gitHubOAuthClient.exchangeCode("invalid_code", null)).willReturn(null);
 
-            assertThatThrownBy(() -> authService.login("invalid_code"))
+            assertThatThrownBy(() -> authService.login("invalid_code", null))
                     .isInstanceOf(InvalidRequestException.class);
         }
     }
@@ -130,15 +132,16 @@ class AuthServiceTest {
         @Test
         @DisplayName("성공: 리프레시 토큰으로 액세스 토큰 갱신")
         void success() {
+            var jwtTokens = new TokenResponse("new_access_token", "new_refresh_token");
             given(jwtTokenProvider.validateToken("valid_refresh")).willReturn(true);
             given(jwtTokenProvider.getUserId("valid_refresh")).willReturn(1L);
             given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
-            given(jwtTokenProvider.createAccessToken(any(), any(), any())).willReturn("new_access_token");
+            given(jwtTokenProvider.createTokens(any(), any(), any())).willReturn(jwtTokens);
 
             TokenResponse result = authService.refresh("valid_refresh");
 
             assertThat(result.accessToken()).isEqualTo("new_access_token");
-            assertThat(result.refreshToken()).isEqualTo("valid_refresh");
+            assertThat(result.refreshToken()).isEqualTo("new_refresh_token");
         }
 
         @Test

--- a/backend/src/test/java/klepaas/backend/deployment/controller/DeploymentControllerTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/controller/DeploymentControllerTest.java
@@ -5,6 +5,7 @@ import klepaas.backend.auth.config.CustomUserDetails;
 import klepaas.backend.auth.config.SecurityConfig;
 import klepaas.backend.auth.jwt.JwtAuthenticationFilter;
 import klepaas.backend.auth.jwt.JwtTokenProvider;
+import klepaas.backend.auth.token.service.CliAccessTokenService;
 import klepaas.backend.deployment.dto.DeploymentResponse;
 import klepaas.backend.deployment.dto.DeploymentStatusResponse;
 import klepaas.backend.deployment.entity.DeploymentStatus;
@@ -50,6 +51,9 @@ class DeploymentControllerTest {
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
+    @MockitoBean
+    private CliAccessTokenService cliAccessTokenService;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final CustomUserDetails testUser = new CustomUserDetails(1L, "test@test.com", Role.USER);
@@ -66,7 +70,7 @@ class DeploymentControllerTest {
     @DisplayName("POST /api/v1/deployments - 배포 생성 성공")
     void createDeployment() throws Exception {
         var response = new DeploymentResponse(
-                1L, 1L, "owner/repo", "main", "abc123",
+                1L, 1L, "owner/repo", "main", "abc1234", "registry.example.com/owner-repo:abc1234",
                 DeploymentStatus.PENDING, null,
                 LocalDateTime.now(), null, LocalDateTime.now());
 
@@ -78,10 +82,11 @@ class DeploymentControllerTest {
                         .content(objectMapper.writeValueAsString(Map.of(
                                 "repository_id", 1,
                                 "branch_name", "main",
-                                "commit_hash", "abc123"
+                                "commit_hash", "abc1234"
                         ))))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.status").value("PENDING"));
+                .andExpect(jsonPath("$.data.status").value("PENDING"))
+                .andExpect(jsonPath("$.data.image_uri").value("registry.example.com/owner-repo:abc1234"));
     }
 
     @Test

--- a/backend/src/test/java/klepaas/backend/deployment/controller/RepositoryControllerTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/controller/RepositoryControllerTest.java
@@ -5,6 +5,7 @@ import klepaas.backend.auth.config.CustomUserDetails;
 import klepaas.backend.auth.config.SecurityConfig;
 import klepaas.backend.auth.jwt.JwtAuthenticationFilter;
 import klepaas.backend.auth.jwt.JwtTokenProvider;
+import klepaas.backend.auth.token.service.CliAccessTokenService;
 import klepaas.backend.deployment.dto.DeploymentConfigResponse;
 import klepaas.backend.deployment.dto.RepositoryResponse;
 import klepaas.backend.deployment.entity.CloudVendor;
@@ -49,6 +50,9 @@ class RepositoryControllerTest {
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CliAccessTokenService cliAccessTokenService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/backend/src/test/java/klepaas/backend/deployment/service/DeploymentServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/service/DeploymentServiceTest.java
@@ -7,7 +7,9 @@ import klepaas.backend.deployment.entity.CloudVendor;
 import klepaas.backend.deployment.entity.Deployment;
 import klepaas.backend.deployment.entity.DeploymentStatus;
 import klepaas.backend.deployment.entity.SourceRepository;
+import klepaas.backend.deployment.repository.DeploymentConfigRepository;
 import klepaas.backend.deployment.repository.DeploymentRepository;
+import klepaas.backend.deployment.repository.ScalingHistoryRepository;
 import klepaas.backend.deployment.repository.SourceRepositoryRepository;
 import klepaas.backend.global.exception.EntityNotFoundException;
 import klepaas.backend.infra.CloudInfraProviderFactory;
@@ -22,7 +24,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +45,10 @@ class DeploymentServiceTest {
     private DeploymentRepository deploymentRepository;
     @Mock
     private SourceRepositoryRepository sourceRepositoryRepository;
+    @Mock
+    private DeploymentConfigRepository deploymentConfigRepository;
+    @Mock
+    private ScalingHistoryRepository scalingHistoryRepository;
     @Mock
     private DeploymentPipelineService pipelineService;
     @Mock
@@ -74,7 +82,7 @@ class DeploymentServiceTest {
         testDeployment = Deployment.builder()
                 .sourceRepository(testRepo)
                 .branchName("main")
-                .commitHash("abc123")
+                .commitHash("abc1234")
                 .build();
     }
 
@@ -85,22 +93,31 @@ class DeploymentServiceTest {
         @Test
         @DisplayName("성공: 배포 생성 후 비동기 파이프라인 실행")
         void success() {
-            var request = new CreateDeploymentRequest(1L, "main", "abc123");
+            var request = new CreateDeploymentRequest(1L, "main", "abc1234");
             given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
             given(deploymentRepository.save(any(Deployment.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-            DeploymentResponse response = deploymentService.createDeployment(request);
+            TransactionSynchronizationManager.initSynchronization();
+            try {
+                DeploymentResponse response = deploymentService.createDeployment(request);
 
-            assertThat(response.branchName()).isEqualTo("main");
-            assertThat(response.commitHash()).isEqualTo("abc123");
-            assertThat(response.status()).isEqualTo(DeploymentStatus.PENDING);
+                assertThat(response.branchName()).isEqualTo("main");
+                assertThat(response.commitHash()).isEqualTo("abc1234");
+                assertThat(response.status()).isEqualTo(DeploymentStatus.PENDING);
+
+                TransactionSynchronizationManager.getSynchronizations()
+                        .forEach(org.springframework.transaction.support.TransactionSynchronization::afterCommit);
+            } finally {
+                TransactionSynchronizationManager.clearSynchronization();
+            }
+
             verify(pipelineService).executePipeline(any());
         }
 
         @Test
         @DisplayName("실패: 존재하지 않는 레포지토리")
         void failRepositoryNotFound() {
-            var request = new CreateDeploymentRequest(999L, "main", "abc123");
+            var request = new CreateDeploymentRequest(999L, "main", "abc1234");
             given(sourceRepositoryRepository.findById(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> deploymentService.createDeployment(request))
@@ -157,6 +174,16 @@ class DeploymentServiceTest {
         @DisplayName("성공: K8s 스케일링 호출")
         void success() {
             given(deploymentRepository.findById(1L)).willReturn(Optional.of(testDeployment));
+            given(deploymentConfigRepository.findBySourceRepositoryId(testRepo.getId()))
+                    .willReturn(Optional.of(klepaas.backend.deployment.entity.DeploymentConfig.builder()
+                            .sourceRepository(testRepo)
+                            .minReplicas(1)
+                            .maxReplicas(3)
+                            .envVars(Map.of())
+                            .containerPort(8080)
+                            .domainUrl("repo.klepaas.io")
+                            .build()));
+            given(scalingHistoryRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
             doNothing().when(k8sGenerator).scale("testowner-testrepo", 3);
 
             deploymentService.scaleDeployment(1L, new klepaas.backend.deployment.dto.ScaleRequest(3));

--- a/backend/src/test/java/klepaas/backend/infra/util/ImageTagGeneratorTest.java
+++ b/backend/src/test/java/klepaas/backend/infra/util/ImageTagGeneratorTest.java
@@ -1,0 +1,44 @@
+package klepaas.backend.infra.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ImageTagGeneratorTest {
+
+    @Test
+    @DisplayName("40자리 커밋 SHA는 앞 7자리 short SHA로 변환한다")
+    void toShortSha() {
+        String commitHash = "abcdef1234567890abcdef1234567890abcdef12";
+
+        assertThat(ImageTagGenerator.toShortSha(commitHash)).isEqualTo("abcdef1");
+    }
+
+    @Test
+    @DisplayName("짧은 SHA도 그대로 태그로 사용한다")
+    void toShortShaWithShortHash() {
+        assertThat(ImageTagGenerator.toShortSha("abc1234")).isEqualTo("abc1234");
+    }
+
+    @Test
+    @DisplayName("imageUri는 registry, imageName, short SHA를 조합한다")
+    void buildImageUri() {
+        String imageUri = ImageTagGenerator.buildImageUri(
+                "registry.example.com",
+                "owner-repo",
+                "abcdef1234567890"
+        );
+
+        assertThat(imageUri).isEqualTo("registry.example.com/owner-repo:abcdef1");
+    }
+
+    @Test
+    @DisplayName("빈 commitHash는 허용하지 않는다")
+    void rejectBlankCommitHash() {
+        assertThatThrownBy(() -> ImageTagGenerator.toShortSha(" "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("commitHash");
+    }
+}


### PR DESCRIPTION
 ## 요약
  - 배포 이미지 태깅을 `latest` 중심 설명/동작에서 commit SHA 기반으로 정리했습니다.
  - `HEAD` 요청이 들어오면 실제 브랜치의 최신 commit SHA로 해석한 뒤 이미지 태그를 생성하도록 변경했습니다.
  - 배포 응답, 테스트, 문서를 현재 동작에 맞게 함께 정리했습니다.

  ## 변경 내용
  - short SHA 및 image URI 생성을 공통화하는 `ImageTagGenerator` 추가
  - `NcpInfraService`에서 commit SHA 기반 이미지 태그 생성하도록 수정
  - `HEAD` 입력 시 실제 commit SHA를 조회해 저장 후 빌드에 사용하도록 처리
  - `Deployment`가 실제 빌드에 사용된 commit hash를 반영할 수 있도록 수정
  - 배포 관련 테스트 및 문서에서 `latest` 전제를 제거하고 현재 정책에 맞게 수정

  ## 기대 효과
  - 배포 결과와 이미지 태그를 commit 단위로 추적할 수 있습니다.
  - 롤백 시 어떤 버전으로 배포되었는지 더 명확하게 식별할 수 있습니다.
  - 포트폴리오 및 면접 설명에서 배포 추적성과 운영 안정성을 더 설득력 있게 설명할 수 있습니다.

  ## 테스트
  - `./gradlew test`

closed #31 