### PR TITLE
feat: Oracle k3s GHCR 배포 MVP 구현

### DIFF
--- a/backend/src/main/java/klepaas/backend/deployment/dto/CreateDeploymentRequest.java
+++ b/backend/src/main/java/klepaas/backend/deployment/dto/CreateDeploymentRequest.java
@@ -8,6 +8,10 @@ public record CreateDeploymentRequest(
         @NotNull Long repositoryId,
         @NotBlank String branchName,
         @Pattern(regexp = "^[a-fA-F0-9]{7,40}$|^HEAD$", message = "commitHash는 7~40자의 hex 문자열 또는 HEAD이어야 합니다")
-        @NotBlank String commitHash
+        @NotBlank String commitHash,
+        String imageUri
 ) {
+    public CreateDeploymentRequest(Long repositoryId, String branchName, String commitHash) {
+        this(repositoryId, branchName, commitHash, null);
+    }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/dto/DeploymentConfigResponse.java
+++ b/backend/src/main/java/klepaas/backend/deployment/dto/DeploymentConfigResponse.java
@@ -1,5 +1,6 @@
 package klepaas.backend.deployment.dto;
 
+import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.DeploymentConfig;
 
 import java.util.Map;
@@ -11,8 +12,17 @@ public record DeploymentConfigResponse(
         int maxReplicas,
         Map<String, String> envVars,
         int containerPort,
-        String domainUrl
+        String domainUrl,
+        BuildStrategy buildStrategy,
+        String imageUriTemplate,
+        String imagePullSecretName
 ) {
+    public DeploymentConfigResponse(Long id, Long repositoryId, int minReplicas, int maxReplicas,
+                                    Map<String, String> envVars, int containerPort, String domainUrl) {
+        this(id, repositoryId, minReplicas, maxReplicas, envVars, containerPort, domainUrl,
+                BuildStrategy.KANIKO, null, null);
+    }
+
     public static DeploymentConfigResponse from(DeploymentConfig entity) {
         return new DeploymentConfigResponse(
                 entity.getId(),
@@ -21,7 +31,10 @@ public record DeploymentConfigResponse(
                 entity.getMaxReplicas(),
                 entity.getEnvVars(),
                 entity.getContainerPort(),
-                entity.getDomainUrl()
+                entity.getDomainUrl(),
+                entity.getBuildStrategy(),
+                entity.getImageUriTemplate(),
+                entity.getImagePullSecretName()
         );
     }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/dto/DeploymentConfigResponse.java
+++ b/backend/src/main/java/klepaas/backend/deployment/dto/DeploymentConfigResponse.java
@@ -2,6 +2,7 @@ package klepaas.backend.deployment.dto;
 
 import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.KubernetesServiceType;
 
 import java.util.Map;
 
@@ -15,12 +16,14 @@ public record DeploymentConfigResponse(
         String domainUrl,
         BuildStrategy buildStrategy,
         String imageUriTemplate,
-        String imagePullSecretName
+        String imagePullSecretName,
+        KubernetesServiceType serviceType,
+        Integer nodePort
 ) {
     public DeploymentConfigResponse(Long id, Long repositoryId, int minReplicas, int maxReplicas,
                                     Map<String, String> envVars, int containerPort, String domainUrl) {
         this(id, repositoryId, minReplicas, maxReplicas, envVars, containerPort, domainUrl,
-                BuildStrategy.KANIKO, null, null);
+                BuildStrategy.KANIKO, null, null, KubernetesServiceType.CLUSTER_IP, null);
     }
 
     public static DeploymentConfigResponse from(DeploymentConfig entity) {
@@ -34,7 +37,9 @@ public record DeploymentConfigResponse(
                 entity.getDomainUrl(),
                 entity.getBuildStrategy(),
                 entity.getImageUriTemplate(),
-                entity.getImagePullSecretName()
+                entity.getImagePullSecretName(),
+                entity.getServiceType(),
+                entity.getNodePort()
         );
     }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/dto/UpdateDeploymentConfigRequest.java
+++ b/backend/src/main/java/klepaas/backend/deployment/dto/UpdateDeploymentConfigRequest.java
@@ -1,6 +1,7 @@
 package klepaas.backend.deployment.dto;
 
 import jakarta.validation.constraints.Min;
+import klepaas.backend.deployment.entity.BuildStrategy;
 
 import java.util.Map;
 
@@ -9,6 +10,13 @@ public record UpdateDeploymentConfigRequest(
         @Min(1) int maxReplicas,
         Map<String, String> envVars,
         @Min(1) int containerPort,
-        String domainUrl
+        String domainUrl,
+        BuildStrategy buildStrategy,
+        String imageUriTemplate,
+        String imagePullSecretName
 ) {
+    public UpdateDeploymentConfigRequest(int minReplicas, int maxReplicas, Map<String, String> envVars,
+                                         int containerPort, String domainUrl) {
+        this(minReplicas, maxReplicas, envVars, containerPort, domainUrl, null, null, null);
+    }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/dto/UpdateDeploymentConfigRequest.java
+++ b/backend/src/main/java/klepaas/backend/deployment/dto/UpdateDeploymentConfigRequest.java
@@ -1,7 +1,9 @@
 package klepaas.backend.deployment.dto;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import klepaas.backend.deployment.entity.BuildStrategy;
+import klepaas.backend.deployment.entity.KubernetesServiceType;
 
 import java.util.Map;
 
@@ -13,10 +15,12 @@ public record UpdateDeploymentConfigRequest(
         String domainUrl,
         BuildStrategy buildStrategy,
         String imageUriTemplate,
-        String imagePullSecretName
+        String imagePullSecretName,
+        KubernetesServiceType serviceType,
+        @Min(30000) @Max(32767) Integer nodePort
 ) {
     public UpdateDeploymentConfigRequest(int minReplicas, int maxReplicas, Map<String, String> envVars,
                                          int containerPort, String domainUrl) {
-        this(minReplicas, maxReplicas, envVars, containerPort, domainUrl, null, null, null);
+        this(minReplicas, maxReplicas, envVars, containerPort, domainUrl, null, null, null, null, null);
     }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/entity/BuildStrategy.java
+++ b/backend/src/main/java/klepaas/backend/deployment/entity/BuildStrategy.java
@@ -1,0 +1,7 @@
+package klepaas.backend.deployment.entity;
+
+public enum BuildStrategy {
+    KANIKO,
+    GITHUB_ACTIONS_GHCR,
+    PREBUILT_IMAGE
+}

--- a/backend/src/main/java/klepaas/backend/deployment/entity/Deployment.java
+++ b/backend/src/main/java/klepaas/backend/deployment/entity/Deployment.java
@@ -76,7 +76,7 @@ public class Deployment extends BaseTimeEntity {
     // 외부 빌드 시작 시
     public void markAsBuilding(String externalBuildId) {
         this.externalBuildId = externalBuildId;
-        // 상태는 이미 BUILDING이거나 유지
+        this.status = DeploymentStatus.BUILDING;
     }
 
     public void setImageUri(String imageUri) {

--- a/backend/src/main/java/klepaas/backend/deployment/entity/DeploymentConfig.java
+++ b/backend/src/main/java/klepaas/backend/deployment/entity/DeploymentConfig.java
@@ -47,10 +47,16 @@ public class DeploymentConfig extends BaseTimeEntity {
 
     private String imagePullSecretName;
 
+    @Enumerated(EnumType.STRING)
+    private KubernetesServiceType serviceType;
+
+    private Integer nodePort;
+
     @Builder
     public DeploymentConfig(SourceRepository sourceRepository, int minReplicas, int maxReplicas,
                             Map<String, String> envVars, int containerPort, String domainUrl,
-                            BuildStrategy buildStrategy, String imageUriTemplate, String imagePullSecretName) {
+                            BuildStrategy buildStrategy, String imageUriTemplate, String imagePullSecretName,
+                            KubernetesServiceType serviceType, Integer nodePort) {
         this.sourceRepository = sourceRepository;
         this.minReplicas = minReplicas;
         this.maxReplicas = maxReplicas;
@@ -60,14 +66,21 @@ public class DeploymentConfig extends BaseTimeEntity {
         this.buildStrategy = buildStrategy != null ? buildStrategy : BuildStrategy.KANIKO;
         this.imageUriTemplate = imageUriTemplate;
         this.imagePullSecretName = imagePullSecretName;
+        this.serviceType = serviceType != null ? serviceType : KubernetesServiceType.CLUSTER_IP;
+        this.nodePort = nodePort;
     }
 
     public BuildStrategy getBuildStrategy() {
         return buildStrategy != null ? buildStrategy : BuildStrategy.KANIKO;
     }
 
+    public KubernetesServiceType getServiceType() {
+        return serviceType != null ? serviceType : KubernetesServiceType.CLUSTER_IP;
+    }
+
     public void updateConfig(int min, int max, Map<String, String> envVars, int containerPort, String domainUrl,
-                             BuildStrategy buildStrategy, String imageUriTemplate, String imagePullSecretName) {
+                             BuildStrategy buildStrategy, String imageUriTemplate, String imagePullSecretName,
+                             KubernetesServiceType serviceType, Integer nodePort) {
         this.minReplicas = min;
         this.maxReplicas = max;
         this.envVars = envVars != null ? envVars : new HashMap<>();
@@ -76,5 +89,7 @@ public class DeploymentConfig extends BaseTimeEntity {
         this.buildStrategy = buildStrategy != null ? buildStrategy : getBuildStrategy();
         this.imageUriTemplate = imageUriTemplate != null ? imageUriTemplate : this.imageUriTemplate;
         this.imagePullSecretName = imagePullSecretName != null ? imagePullSecretName : this.imagePullSecretName;
+        this.serviceType = serviceType != null ? serviceType : getServiceType();
+        this.nodePort = nodePort;
     }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/entity/DeploymentConfig.java
+++ b/backend/src/main/java/klepaas/backend/deployment/entity/DeploymentConfig.java
@@ -40,22 +40,41 @@ public class DeploymentConfig extends BaseTimeEntity {
     @Column(nullable = false)
     private String domainUrl;
 
+    @Enumerated(EnumType.STRING)
+    private BuildStrategy buildStrategy;
+
+    private String imageUriTemplate;
+
+    private String imagePullSecretName;
+
     @Builder
     public DeploymentConfig(SourceRepository sourceRepository, int minReplicas, int maxReplicas,
-                            Map<String, String> envVars, int containerPort, String domainUrl) {
+                            Map<String, String> envVars, int containerPort, String domainUrl,
+                            BuildStrategy buildStrategy, String imageUriTemplate, String imagePullSecretName) {
         this.sourceRepository = sourceRepository;
         this.minReplicas = minReplicas;
         this.maxReplicas = maxReplicas;
         this.envVars = envVars != null ? envVars : new HashMap<>();
         this.containerPort = containerPort > 0 ? containerPort : 8080;
         this.domainUrl = domainUrl;
+        this.buildStrategy = buildStrategy != null ? buildStrategy : BuildStrategy.KANIKO;
+        this.imageUriTemplate = imageUriTemplate;
+        this.imagePullSecretName = imagePullSecretName;
     }
 
-    public void updateConfig(int min, int max, Map<String, String> envVars, int containerPort, String domainUrl) {
+    public BuildStrategy getBuildStrategy() {
+        return buildStrategy != null ? buildStrategy : BuildStrategy.KANIKO;
+    }
+
+    public void updateConfig(int min, int max, Map<String, String> envVars, int containerPort, String domainUrl,
+                             BuildStrategy buildStrategy, String imageUriTemplate, String imagePullSecretName) {
         this.minReplicas = min;
         this.maxReplicas = max;
         this.envVars = envVars != null ? envVars : new HashMap<>();
         this.containerPort = containerPort > 0 ? containerPort : 8080;
         this.domainUrl = domainUrl;
+        this.buildStrategy = buildStrategy != null ? buildStrategy : getBuildStrategy();
+        this.imageUriTemplate = imageUriTemplate != null ? imageUriTemplate : this.imageUriTemplate;
+        this.imagePullSecretName = imagePullSecretName != null ? imagePullSecretName : this.imagePullSecretName;
     }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/entity/KubernetesServiceType.java
+++ b/backend/src/main/java/klepaas/backend/deployment/entity/KubernetesServiceType.java
@@ -1,0 +1,16 @@
+package klepaas.backend.deployment.entity;
+
+public enum KubernetesServiceType {
+    CLUSTER_IP("ClusterIP"),
+    NODE_PORT("NodePort");
+
+    private final String kubernetesValue;
+
+    KubernetesServiceType(String kubernetesValue) {
+        this.kubernetesValue = kubernetesValue;
+    }
+
+    public String getKubernetesValue() {
+        return kubernetesValue;
+    }
+}

--- a/backend/src/main/java/klepaas/backend/deployment/service/DeploymentPipelineService.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/DeploymentPipelineService.java
@@ -1,5 +1,6 @@
 package klepaas.backend.deployment.service;
 
+import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.Deployment;
 import klepaas.backend.deployment.repository.DeploymentRepository;
 import klepaas.backend.global.exception.BusinessException;
@@ -44,22 +45,15 @@ public class DeploymentPipelineService {
         Long userId = deploymentRepository.findUserIdByDeploymentId(deploymentId).orElse(null);
 
         try {
-            // 1. 소스 업로드
-            notifyWs(deploymentId, userId, "UPLOADING", "in_progress", 10, "소스 코드 업로드 중...");
-            String storageKey = stepService.executeUpload(deploymentId);
+            BuildStrategy buildStrategy = stepService.getBuildStrategy(deploymentId);
+            String imageUri = switch (buildStrategy) {
+                case KANIKO -> executeKanikoBuild(deploymentId, userId);
+                case GITHUB_ACTIONS_GHCR, PREBUILT_IMAGE -> resolveExternalImage(deploymentId, userId);
+            };
 
-            // 2. 빌드 트리거
-            notifyWs(deploymentId, userId, "BUILDING", "in_progress", 30, "컨테이너 이미지 빌드 중...");
-            BuildResult buildResult = stepService.executeBuildTrigger(deploymentId, storageKey);
-
-            // 3. 빌드 폴링
-            BuildStatusResult statusResult = pollBuildStatus(deploymentId, buildResult);
-
-            // 4. K8s 배포
             notifyWs(deploymentId, userId, "DEPLOYING", "in_progress", 70, "Kubernetes에 배포 중...");
-            stepService.executeK8sDeploy(deploymentId, statusResult.imageUri());
+            stepService.executeK8sDeploy(deploymentId, imageUri);
 
-            // 5. 성공 처리
             stepService.markSuccess(deploymentId);
             notifyWs(deploymentId, userId, "SUCCESS", "completed", 100, "배포가 완료되었습니다.");
             log.info("Pipeline completed successfully: deploymentId={}", deploymentId);
@@ -69,6 +63,21 @@ public class DeploymentPipelineService {
             stepService.markFailed(deploymentId, e.getMessage());
             notifyWs(deploymentId, userId, "FAILED", "failed", 0, "배포 실패: " + e.getMessage());
         }
+    }
+
+    private String executeKanikoBuild(Long deploymentId, Long userId) {
+        notifyWs(deploymentId, userId, "UPLOADING", "in_progress", 10, "소스 코드 업로드 중...");
+        String storageKey = stepService.executeUpload(deploymentId);
+
+        notifyWs(deploymentId, userId, "BUILDING", "in_progress", 30, "컨테이너 이미지 빌드 중...");
+        BuildResult buildResult = stepService.executeBuildTrigger(deploymentId, storageKey);
+        BuildStatusResult statusResult = pollBuildStatus(deploymentId, buildResult);
+        return statusResult.imageUri();
+    }
+
+    private String resolveExternalImage(Long deploymentId, Long userId) {
+        notifyWs(deploymentId, userId, "BUILDING", "in_progress", 30, "외부 컨테이너 이미지 확인 중...");
+        return stepService.resolveExternalImage(deploymentId);
     }
 
     private BuildStatusResult pollBuildStatus(Long deploymentId, BuildResult buildResult) {

--- a/backend/src/main/java/klepaas/backend/deployment/service/DeploymentPipelineStepService.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/DeploymentPipelineStepService.java
@@ -1,6 +1,7 @@
 package klepaas.backend.deployment.service;
 
 import klepaas.backend.auth.service.GitHubInstallationTokenService;
+import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.Deployment;
 import klepaas.backend.deployment.entity.DeploymentConfig;
 import klepaas.backend.deployment.entity.SourceRepository;
@@ -32,6 +33,16 @@ public class DeploymentPipelineStepService {
     private final KubernetesManifestGenerator k8sGenerator;
     private final GitHubInstallationTokenService installationTokenService;
     private final NotificationService notificationService;
+    private final ExternalImageResolver externalImageResolver;
+
+    @Transactional(readOnly = true)
+    public BuildStrategy getBuildStrategy(Long deploymentId) {
+        Deployment deployment = getDeployment(deploymentId);
+        DeploymentConfig config = deploymentConfigRepository.findBySourceRepositoryId(
+                        deployment.getSourceRepository().getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.DEPLOYMENT_CONFIG_NOT_FOUND));
+        return config.getBuildStrategy();
+    }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public String executeUpload(Long deploymentId) {
@@ -72,6 +83,22 @@ public class DeploymentPipelineStepService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public String resolveExternalImage(Long deploymentId) {
+        Deployment deployment = getDeployment(deploymentId);
+        DeploymentConfig config = deploymentConfigRepository.findBySourceRepositoryId(
+                        deployment.getSourceRepository().getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.DEPLOYMENT_CONFIG_NOT_FOUND));
+
+        String imageUri = externalImageResolver.resolve(deployment, config);
+        deployment.markAsBuilding("external-image");
+        deployment.setImageUri(imageUri);
+        deploymentRepository.save(deployment);
+
+        log.info("External image resolved: deploymentId={}, imageUri={}", deploymentId, imageUri);
+        return imageUri;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void executeK8sDeploy(Long deploymentId, String imageUri) {
         Deployment deployment = getDeployment(deploymentId);
         deployment.startDeploying();
@@ -85,6 +112,7 @@ public class DeploymentPipelineStepService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.DEPLOYMENT_CONFIG_NOT_FOUND));
 
         k8sGenerator.deploy(appName, imageUri, config, repo.getId());
+        k8sGenerator.waitForDeploymentAvailable(appName);
         log.info("K8s deploy completed: deploymentId={}, app={}", deploymentId, appName);
     }
 

--- a/backend/src/main/java/klepaas/backend/deployment/service/DeploymentService.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/DeploymentService.java
@@ -53,6 +53,9 @@ public class DeploymentService {
                 .branchName(request.branchName())
                 .commitHash(request.commitHash())
                 .build();
+        if (request.imageUri() != null && !request.imageUri().isBlank()) {
+            deployment.setImageUri(request.imageUri());
+        }
         deploymentRepository.save(deployment);
 
         log.info("Deployment created: id={}, repo={}/{}, branch={}", deployment.getId(),

--- a/backend/src/main/java/klepaas/backend/deployment/service/ExternalImageResolver.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/ExternalImageResolver.java
@@ -1,0 +1,46 @@
+package klepaas.backend.deployment.service;
+
+import klepaas.backend.deployment.entity.Deployment;
+import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.SourceRepository;
+import klepaas.backend.global.exception.BusinessException;
+import klepaas.backend.global.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExternalImageResolver {
+
+    public String resolve(Deployment deployment, DeploymentConfig config) {
+        if (hasText(deployment.getImageUri())) {
+            return deployment.getImageUri();
+        }
+        if ("HEAD".equals(deployment.getCommitHash())) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_REQUEST,
+                    "외부 이미지 배포는 HEAD 대신 확정 commitHash 또는 imageUri가 필요합니다"
+            );
+        }
+
+        String template = config.getImageUriTemplate();
+        if (!hasText(template)) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_REQUEST,
+                    "외부 이미지 배포는 imageUri 또는 imageUriTemplate 설정이 필요합니다"
+            );
+        }
+
+        SourceRepository repository = deployment.getSourceRepository();
+        String commitHash = deployment.getCommitHash();
+        String shortCommitHash = commitHash.substring(0, Math.min(7, commitHash.length()));
+
+        return template
+                .replace("{owner}", repository.getOwner().toLowerCase())
+                .replace("{repoName}", repository.getRepoName())
+                .replace("{commitHash}", commitHash)
+                .replace("{shortCommitHash}", shortCommitHash);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/backend/src/main/java/klepaas/backend/deployment/service/RepositoryService.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/RepositoryService.java
@@ -6,6 +6,7 @@ import klepaas.backend.deployment.dto.*;
 import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.CloudVendor;
 import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.KubernetesServiceType;
 import klepaas.backend.deployment.entity.SourceRepository;
 import klepaas.backend.deployment.repository.DeploymentConfigRepository;
 import klepaas.backend.deployment.repository.SourceRepositoryRepository;
@@ -14,6 +15,7 @@ import klepaas.backend.global.exception.EntityNotFoundException;
 import klepaas.backend.global.exception.ErrorCode;
 import klepaas.backend.global.exception.GitHubAppInstallationRequiredException;
 import klepaas.backend.global.exception.GitHubAppNotInstalledException;
+import klepaas.backend.global.exception.InvalidRequestException;
 import klepaas.backend.user.entity.User;
 import klepaas.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -123,6 +125,7 @@ public class RepositoryService {
         DeploymentConfig config = deploymentConfigRepository.findBySourceRepositoryId(repositoryId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.DEPLOYMENT_CONFIG_NOT_FOUND));
 
+        ServiceExposure serviceExposure = resolveServiceExposure(config, request);
         config.updateConfig(
                 request.minReplicas(),
                 request.maxReplicas(),
@@ -131,11 +134,33 @@ public class RepositoryService {
                 request.domainUrl(),
                 request.buildStrategy(),
                 request.imageUriTemplate(),
-                request.imagePullSecretName()
+                request.imagePullSecretName(),
+                serviceExposure.serviceType(),
+                serviceExposure.nodePort()
         );
 
         log.info("DeploymentConfig updated: repositoryId={}", repositoryId);
         return DeploymentConfigResponse.from(config);
+    }
+
+    private ServiceExposure resolveServiceExposure(DeploymentConfig config, UpdateDeploymentConfigRequest request) {
+        KubernetesServiceType serviceType = request.serviceType() != null
+                ? request.serviceType()
+                : config.getServiceType();
+        Integer nodePort = request.nodePort() != null ? request.nodePort() : config.getNodePort();
+
+        if (serviceType == KubernetesServiceType.NODE_PORT && nodePort == null) {
+            throw new InvalidRequestException(ErrorCode.INVALID_REQUEST, "NODE_PORT 서비스는 nodePort가 필요합니다");
+        }
+
+        if (serviceType == KubernetesServiceType.CLUSTER_IP) {
+            if (request.nodePort() != null) {
+                throw new InvalidRequestException(ErrorCode.INVALID_REQUEST, "CLUSTER_IP 서비스에는 nodePort를 설정할 수 없습니다");
+            }
+            return new ServiceExposure(serviceType, null);
+        }
+
+        return new ServiceExposure(serviceType, nodePort);
     }
 
     private BuildStrategy defaultBuildStrategy(CloudVendor cloudVendor) {
@@ -143,6 +168,9 @@ public class RepositoryService {
             case NCP, AWS -> BuildStrategy.KANIKO;
             case ON_PREMISE -> BuildStrategy.GITHUB_ACTIONS_GHCR;
         };
+    }
+
+    private record ServiceExposure(KubernetesServiceType serviceType, Integer nodePort) {
     }
 
 }

--- a/backend/src/main/java/klepaas/backend/deployment/service/RepositoryService.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/RepositoryService.java
@@ -3,6 +3,8 @@ package klepaas.backend.deployment.service;
 import klepaas.backend.auth.config.GitHubAppConfig;
 import klepaas.backend.auth.oauth.GitHubAppClient;
 import klepaas.backend.deployment.dto.*;
+import klepaas.backend.deployment.entity.BuildStrategy;
+import klepaas.backend.deployment.entity.CloudVendor;
 import klepaas.backend.deployment.entity.DeploymentConfig;
 import klepaas.backend.deployment.entity.SourceRepository;
 import klepaas.backend.deployment.repository.DeploymentConfigRepository;
@@ -62,6 +64,7 @@ public class RepositoryService {
                 .envVars(new HashMap<>())
                 .containerPort(8080)
                 .domainUrl(request.repoName() + ".klepaas.io")
+                .buildStrategy(defaultBuildStrategy(request.cloudVendor()))
                 .build();
         deploymentConfigRepository.save(defaultConfig);
 
@@ -125,10 +128,21 @@ public class RepositoryService {
                 request.maxReplicas(),
                 request.envVars(),
                 request.containerPort(),
-                request.domainUrl()
+                request.domainUrl(),
+                request.buildStrategy(),
+                request.imageUriTemplate(),
+                request.imagePullSecretName()
         );
 
         log.info("DeploymentConfig updated: repositoryId={}", repositoryId);
         return DeploymentConfigResponse.from(config);
     }
+
+    private BuildStrategy defaultBuildStrategy(CloudVendor cloudVendor) {
+        return switch (cloudVendor) {
+            case NCP, AWS -> BuildStrategy.KANIKO;
+            case ON_PREMISE -> BuildStrategy.GITHUB_ACTIONS_GHCR;
+        };
+    }
+
 }

--- a/backend/src/main/java/klepaas/backend/infra/kubernetes/KubernetesManifestGenerator.java
+++ b/backend/src/main/java/klepaas/backend/infra/kubernetes/KubernetesManifestGenerator.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.KubernetesServiceType;
 import klepaas.backend.global.exception.BusinessException;
 import klepaas.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,7 @@ public class KubernetesManifestGenerator {
 
         try {
             createOrUpdateDeployment(appName, imageUri, config, labels);
-            createOrUpdateService(appName, config.getContainerPort(), labels);
+            createOrUpdateService(appName, config, labels);
 
             if (config.getDomainUrl() != null && !config.getDomainUrl().isBlank()) {
                 createOrUpdateIngress(appName, config.getDomainUrl(), config.getContainerPort(), labels);
@@ -190,7 +191,8 @@ public class KubernetesManifestGenerator {
         return imagePullSecretName;
     }
 
-    private void createOrUpdateService(String appName, int containerPort, Map<String, String> labels) {
+    private void createOrUpdateService(String appName, DeploymentConfig config, Map<String, String> labels) {
+        ServicePort servicePort = buildServicePort(config);
         Service service = new ServiceBuilder()
                 .withNewMetadata()
                     .withName(appName)
@@ -199,12 +201,8 @@ public class KubernetesManifestGenerator {
                 .endMetadata()
                 .withNewSpec()
                     .withSelector(Map.of("app.kubernetes.io/name", appName))
-                    .withPorts(new ServicePortBuilder()
-                            .withPort(80)
-                            .withNewTargetPort(containerPort)
-                            .withProtocol("TCP")
-                            .build())
-                    .withType("ClusterIP")
+                    .withPorts(servicePort)
+                    .withType(config.getServiceType().getKubernetesValue())
                 .endSpec()
                 .build();
 
@@ -212,6 +210,17 @@ public class KubernetesManifestGenerator {
                 .inNamespace(namespace)
                 .resource(service)
                 .serverSideApply();
+    }
+
+    ServicePort buildServicePort(DeploymentConfig config) {
+        ServicePortBuilder builder = new ServicePortBuilder()
+                .withPort(80)
+                .withNewTargetPort(config.getContainerPort())
+                .withProtocol("TCP");
+        if (config.getServiceType() == KubernetesServiceType.NODE_PORT && config.getNodePort() != null) {
+            builder.withNodePort(config.getNodePort());
+        }
+        return builder.build();
     }
 
     private void createOrUpdateIngress(String appName, String domainUrl, int containerPort,

--- a/backend/src/main/java/klepaas/backend/infra/kubernetes/KubernetesManifestGenerator.java
+++ b/backend/src/main/java/klepaas/backend/infra/kubernetes/KubernetesManifestGenerator.java
@@ -3,6 +3,7 @@ package klepaas.backend.infra.kubernetes;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
 
@@ -31,6 +32,12 @@ public class KubernetesManifestGenerator {
 
     @Value("${kubernetes.image-pull-secret:ncp-cr}")
     private String imagePullSecretName;
+
+    @Value("${kubernetes.rollout.timeout-ms:120000}")
+    private long rolloutTimeoutMs;
+
+    @Value("${kubernetes.rollout.poll-interval-ms:2000}")
+    private long rolloutPollIntervalMs;
 
     /**
      * K8s Deployment + Service + Ingress 생성/업데이트
@@ -68,6 +75,69 @@ public class KubernetesManifestGenerator {
         log.info("Scaled: app={}, replicas={}", appName, replicas);
     }
 
+    public void waitForDeploymentAvailable(String appName) {
+        long deadline = System.currentTimeMillis() + rolloutTimeoutMs;
+        while (System.currentTimeMillis() <= deadline) {
+            Deployment deployment = kubernetesClient.apps().deployments()
+                    .inNamespace(namespace)
+                    .withName(appName)
+                    .get();
+            if (isDeploymentRolloutComplete(deployment)) {
+                log.info("Deployment rollout available: app={}, namespace={}", appName, namespace);
+                return;
+            }
+            sleepBeforeNextRolloutCheck(appName);
+        }
+        throw new BusinessException(
+                ErrorCode.DEPLOY_FAILED,
+                "K8s rollout 타임아웃: " + appName + " Deployment가 Available 상태가 아닙니다"
+        );
+    }
+
+    boolean isDeploymentRolloutComplete(Deployment deployment) {
+        if (deployment == null
+                || deployment.getMetadata() == null
+                || deployment.getSpec() == null
+                || deployment.getStatus() == null
+                || deployment.getStatus().getConditions() == null) {
+            return false;
+        }
+        int desiredReplicas = valueOrZero(deployment.getSpec().getReplicas());
+        int updatedReplicas = valueOrZero(deployment.getStatus().getUpdatedReplicas());
+        int availableReplicas = valueOrZero(deployment.getStatus().getAvailableReplicas());
+        int unavailableReplicas = valueOrZero(deployment.getStatus().getUnavailableReplicas());
+        long generation = valueOrZero(deployment.getMetadata().getGeneration());
+        long observedGeneration = valueOrZero(deployment.getStatus().getObservedGeneration());
+
+        return deployment.getStatus().getConditions().stream()
+                .anyMatch(this::isAvailableCondition)
+                && observedGeneration >= generation
+                && updatedReplicas == desiredReplicas
+                && availableReplicas == desiredReplicas
+                && unavailableReplicas == 0;
+    }
+
+    private boolean isAvailableCondition(DeploymentCondition condition) {
+        return "Available".equals(condition.getType()) && "True".equals(condition.getStatus());
+    }
+
+    private int valueOrZero(Integer value) {
+        return value != null ? value : 0;
+    }
+
+    private long valueOrZero(Long value) {
+        return value != null ? value : 0L;
+    }
+
+    private void sleepBeforeNextRolloutCheck(String appName) {
+        try {
+            Thread.sleep(rolloutPollIntervalMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(ErrorCode.DEPLOY_FAILED, "K8s rollout 대기 중단됨: " + appName);
+        }
+    }
+
     private void createOrUpdateDeployment(String appName, String imageUri,
                                            DeploymentConfig config, Map<String, String> labels) {
         List<EnvVar> envVars = config.getEnvVars().entrySet().stream()
@@ -91,7 +161,7 @@ public class KubernetesManifestGenerator {
                         .endMetadata()
                         .withNewSpec()
                             .withImagePullSecrets(new LocalObjectReferenceBuilder()
-                                    .withName(imagePullSecretName)
+                                    .withName(resolveImagePullSecretName(config))
                                     .build())
                             .withContainers(new ContainerBuilder()
                                     .withName(appName)
@@ -110,6 +180,14 @@ public class KubernetesManifestGenerator {
                 .inNamespace(namespace)
                 .resource(deployment)
                 .serverSideApply();
+    }
+
+    private String resolveImagePullSecretName(DeploymentConfig config) {
+        String configured = config.getImagePullSecretName();
+        if (configured != null && !configured.isBlank()) {
+            return configured;
+        }
+        return imagePullSecretName;
     }
 
     private void createOrUpdateService(String appName, int containerPort, Map<String, String> labels) {

--- a/backend/src/main/java/klepaas/backend/webhook/service/GitHubWebhookService.java
+++ b/backend/src/main/java/klepaas/backend/webhook/service/GitHubWebhookService.java
@@ -3,7 +3,10 @@ package klepaas.backend.webhook.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import klepaas.backend.deployment.dto.CreateDeploymentRequest;
+import klepaas.backend.deployment.entity.BuildStrategy;
+import klepaas.backend.deployment.entity.CloudVendor;
 import klepaas.backend.deployment.entity.SourceRepository;
+import klepaas.backend.deployment.repository.DeploymentConfigRepository;
 import klepaas.backend.deployment.repository.SourceRepositoryRepository;
 import klepaas.backend.deployment.service.DeploymentService;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,7 @@ public class GitHubWebhookService {
     private String webhookSecret;
 
     private final SourceRepositoryRepository sourceRepositoryRepository;
+    private final DeploymentConfigRepository deploymentConfigRepository;
     private final DeploymentService deploymentService;
     private final ObjectMapper objectMapper;
 
@@ -75,11 +79,34 @@ public class GitHubWebhookService {
             }
 
             SourceRepository repo = repoOpt.get();
+            if (shouldSkipPushDeployment(repo)) {
+                log.info("외부 이미지 전략 저장소의 raw push 배포 무시: repo={}/{}, branch={}, commit={}",
+                        owner, repoName, branch, commitHash);
+                return;
+            }
+
             log.info("GitHub push 이벤트 처리: repo={}/{}, branch={}, commit={}", owner, repoName, branch, commitHash);
             deploymentService.createDeployment(new CreateDeploymentRequest(repo.getId(), branch, commitHash), null);
 
         } catch (Exception e) {
             log.error("GitHub push 이벤트 처리 중 오류 발생", e);
         }
+    }
+
+    private boolean shouldSkipPushDeployment(SourceRepository repository) {
+        BuildStrategy buildStrategy = deploymentConfigRepository.findBySourceRepositoryId(repository.getId())
+                .map(config -> config.getBuildStrategy())
+                .orElse(defaultBuildStrategy(repository));
+        return switch (buildStrategy) {
+            case KANIKO -> false;
+            case GITHUB_ACTIONS_GHCR, PREBUILT_IMAGE -> true;
+        };
+    }
+
+    private BuildStrategy defaultBuildStrategy(SourceRepository repository) {
+        if (repository.getCloudVendor() == CloudVendor.ON_PREMISE) {
+            return BuildStrategy.GITHUB_ACTIONS_GHCR;
+        }
+        return BuildStrategy.KANIKO;
     }
 }

--- a/backend/src/test/java/klepaas/backend/deployment/controller/DeploymentControllerTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/controller/DeploymentControllerTest.java
@@ -8,12 +8,14 @@ import klepaas.backend.auth.jwt.JwtTokenProvider;
 import klepaas.backend.auth.token.service.CliAccessTokenService;
 import klepaas.backend.deployment.dto.DeploymentResponse;
 import klepaas.backend.deployment.dto.DeploymentStatusResponse;
+import klepaas.backend.deployment.dto.CreateDeploymentRequest;
 import klepaas.backend.deployment.entity.DeploymentStatus;
 import klepaas.backend.deployment.service.DeploymentService;
 import klepaas.backend.user.entity.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -29,6 +31,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -69,8 +72,9 @@ class DeploymentControllerTest {
     @Test
     @DisplayName("POST /api/v1/deployments - 배포 생성 성공")
     void createDeployment() throws Exception {
+        String imageUri = "ghcr.io/kjhyeon0620/smart-sousvide-iot-platform/backend:sha-abc1234";
         var response = new DeploymentResponse(
-                1L, 1L, "owner/repo", "main", "abc1234", "registry.example.com/owner-repo:abc1234",
+                1L, 1L, "owner/repo", "main", "abc1234", imageUri,
                 DeploymentStatus.PENDING, null,
                 LocalDateTime.now(), null, LocalDateTime.now());
 
@@ -82,11 +86,16 @@ class DeploymentControllerTest {
                         .content(objectMapper.writeValueAsString(Map.of(
                                 "repository_id", 1,
                                 "branch_name", "main",
-                                "commit_hash", "abc1234"
+                                "commit_hash", "abc1234",
+                                "image_uri", imageUri
                         ))))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.status").value("PENDING"))
-                .andExpect(jsonPath("$.data.image_uri").value("registry.example.com/owner-repo:abc1234"));
+                .andExpect(jsonPath("$.data.image_uri").value(imageUri));
+
+        ArgumentCaptor<CreateDeploymentRequest> requestCaptor = ArgumentCaptor.forClass(CreateDeploymentRequest.class);
+        verify(deploymentService).createDeployment(requestCaptor.capture(), eq(1L));
+        org.assertj.core.api.Assertions.assertThat(requestCaptor.getValue().imageUri()).isEqualTo(imageUri);
     }
 
     @Test

--- a/backend/src/test/java/klepaas/backend/deployment/entity/DeploymentTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/entity/DeploymentTest.java
@@ -1,0 +1,42 @@
+package klepaas.backend.deployment.entity;
+
+import klepaas.backend.user.entity.Role;
+import klepaas.backend.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeploymentTest {
+
+    @Test
+    @DisplayName("markAsBuilding은 externalBuildId 저장과 함께 BUILDING 상태로 전이한다")
+    void markAsBuilding_setsStatusToBuilding() {
+        Deployment deployment = Deployment.builder()
+                .sourceRepository(repository())
+                .branchName("main")
+                .commitHash("abcdef1234567890")
+                .build();
+
+        deployment.markAsBuilding("external-image");
+
+        assertThat(deployment.getExternalBuildId()).isEqualTo("external-image");
+        assertThat(deployment.getStatus()).isEqualTo(DeploymentStatus.BUILDING);
+    }
+
+    private SourceRepository repository() {
+        User user = User.builder()
+                .email("test@example.com")
+                .name("tester")
+                .role(Role.USER)
+                .providerId("12345")
+                .build();
+        return SourceRepository.builder()
+                .user(user)
+                .owner("kjhyeon0620")
+                .repoName("smart-sousvide-iot-platform")
+                .gitUrl("https://github.com/kjhyeon0620/smart-sousvide-iot-platform")
+                .cloudVendor(CloudVendor.ON_PREMISE)
+                .build();
+    }
+}

--- a/backend/src/test/java/klepaas/backend/deployment/service/DeploymentPipelineServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/service/DeploymentPipelineServiceTest.java
@@ -1,0 +1,145 @@
+package klepaas.backend.deployment.service;
+
+import klepaas.backend.deployment.entity.BuildStrategy;
+import klepaas.backend.deployment.entity.CloudVendor;
+import klepaas.backend.deployment.entity.Deployment;
+import klepaas.backend.deployment.entity.SourceRepository;
+import klepaas.backend.deployment.repository.DeploymentRepository;
+import klepaas.backend.global.websocket.WebSocketNotificationService;
+import klepaas.backend.infra.CloudInfraProvider;
+import klepaas.backend.infra.CloudInfraProviderFactory;
+import klepaas.backend.infra.dto.BuildResult;
+import klepaas.backend.infra.dto.BuildStatusResult;
+import klepaas.backend.user.entity.Role;
+import klepaas.backend.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeploymentPipelineServiceTest {
+
+    @Mock
+    private DeploymentPipelineStepService stepService;
+
+    @Mock
+    private DeploymentRepository deploymentRepository;
+
+    @Mock
+    private CloudInfraProviderFactory infraProviderFactory;
+
+    @Mock
+    private WebSocketNotificationService wsNotificationService;
+
+    @Mock
+    private CloudInfraProvider cloudInfraProvider;
+
+    @InjectMocks
+    private DeploymentPipelineService deploymentPipelineService;
+
+    private Deployment ncpDeployment;
+    private Deployment onPremiseDeployment;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .email("test@example.com")
+                .name("tester")
+                .role(Role.USER)
+                .providerId("12345")
+                .build();
+
+        SourceRepository ncpRepository = SourceRepository.builder()
+                .user(user)
+                .owner("testowner")
+                .repoName("testrepo")
+                .gitUrl("https://github.com/testowner/testrepo")
+                .cloudVendor(CloudVendor.NCP)
+                .build();
+
+        SourceRepository onPremiseRepository = SourceRepository.builder()
+                .user(user)
+                .owner("kjhyeon0620")
+                .repoName("smart-sousvide-iot-platform")
+                .gitUrl("https://github.com/kjhyeon0620/smart-sousvide-iot-platform")
+                .cloudVendor(CloudVendor.ON_PREMISE)
+                .build();
+
+        ncpDeployment = Deployment.builder()
+                .sourceRepository(ncpRepository)
+                .branchName("main")
+                .commitHash("abcdef1234567890")
+                .build();
+
+        onPremiseDeployment = Deployment.builder()
+                .sourceRepository(onPremiseRepository)
+                .branchName("main")
+                .commitHash("abcdef1234567890")
+                .build();
+
+        ReflectionTestUtils.setField(deploymentPipelineService, "pollInitialInterval", 1L);
+        ReflectionTestUtils.setField(deploymentPipelineService, "pollMaxInterval", 1L);
+        ReflectionTestUtils.setField(deploymentPipelineService, "buildTimeout", 100L);
+    }
+
+    @Test
+    @DisplayName("KANIKO 전략은 기존 upload/build/poll/deploy 흐름을 유지한다")
+    void executePipeline_usesKanikoFlow_whenBuildStrategyIsKaniko() {
+        // Given
+        BuildResult buildResult = new BuildResult(
+                "klepaas-build-1",
+                "default",
+                "registry.example.com/testowner-testrepo:abcdef1"
+        );
+        given(deploymentRepository.findUserIdByDeploymentId(1L)).willReturn(Optional.of(10L));
+        given(stepService.getBuildStrategy(1L)).willReturn(BuildStrategy.KANIKO);
+        given(stepService.executeUpload(1L)).willReturn("builds/1/source.zip");
+        given(stepService.executeBuildTrigger(1L, "builds/1/source.zip")).willReturn(buildResult);
+        given(deploymentRepository.findById(1L)).willReturn(Optional.of(ncpDeployment));
+        given(infraProviderFactory.getProvider(CloudVendor.NCP)).willReturn(cloudInfraProvider);
+        given(cloudInfraProvider.getBuildStatus("default", "klepaas-build-1"))
+                .willReturn(new BuildStatusResult(true, true, null, "success"));
+
+        // When
+        deploymentPipelineService.executePipeline(1L);
+
+        // Then
+        verify(stepService).executeUpload(1L);
+        verify(stepService).executeBuildTrigger(1L, "builds/1/source.zip");
+        verify(stepService).executeK8sDeploy(1L, "registry.example.com/testowner-testrepo:abcdef1");
+        verify(stepService).markSuccess(1L);
+    }
+
+    @Test
+    @DisplayName("GITHUB_ACTIONS_GHCR 전략은 source upload와 Kaniko build를 건너뛰고 외부 이미지를 배포한다")
+    void executePipeline_usesExternalImageFlow_whenBuildStrategyIsGitHubActionsGhcr() {
+        // Given
+        String imageUri = "ghcr.io/kjhyeon0620/smart-sousvide-iot-platform/backend:sha-abcdef1234567890";
+        given(deploymentRepository.findUserIdByDeploymentId(2L)).willReturn(Optional.of(10L));
+        given(stepService.getBuildStrategy(2L)).willReturn(BuildStrategy.GITHUB_ACTIONS_GHCR);
+        given(stepService.resolveExternalImage(2L)).willReturn(imageUri);
+
+        // When
+        deploymentPipelineService.executePipeline(2L);
+
+        // Then
+        verify(stepService, never()).executeUpload(2L);
+        verify(stepService, never()).executeBuildTrigger(eq(2L), anyString());
+        verify(stepService).resolveExternalImage(2L);
+        verify(stepService).executeK8sDeploy(2L, imageUri);
+        verify(stepService).markSuccess(2L);
+    }
+}

--- a/backend/src/test/java/klepaas/backend/deployment/service/DeploymentPipelineStepServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/service/DeploymentPipelineStepServiceTest.java
@@ -1,0 +1,106 @@
+package klepaas.backend.deployment.service;
+
+import klepaas.backend.auth.service.GitHubInstallationTokenService;
+import klepaas.backend.deployment.entity.CloudVendor;
+import klepaas.backend.deployment.entity.Deployment;
+import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.SourceRepository;
+import klepaas.backend.deployment.repository.DeploymentConfigRepository;
+import klepaas.backend.deployment.repository.DeploymentRepository;
+import klepaas.backend.deployment.repository.SourceRepositoryRepository;
+import klepaas.backend.global.service.NotificationService;
+import klepaas.backend.infra.CloudInfraProviderFactory;
+import klepaas.backend.infra.kubernetes.KubernetesManifestGenerator;
+import klepaas.backend.user.entity.Role;
+import klepaas.backend.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeploymentPipelineStepServiceTest {
+
+    @Mock
+    private DeploymentRepository deploymentRepository;
+
+    @Mock
+    private SourceRepositoryRepository sourceRepositoryRepository;
+
+    @Mock
+    private DeploymentConfigRepository deploymentConfigRepository;
+
+    @Mock
+    private CloudInfraProviderFactory infraProviderFactory;
+
+    @Mock
+    private KubernetesManifestGenerator k8sGenerator;
+
+    @Mock
+    private GitHubInstallationTokenService installationTokenService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private ExternalImageResolver externalImageResolver;
+
+    @InjectMocks
+    private DeploymentPipelineStepService stepService;
+
+    @Test
+    @DisplayName("K8s 배포는 manifest apply 후 rollout available 상태까지 검증한다")
+    void executeK8sDeploy_waitsForRolloutAvailability() {
+        SourceRepository repository = repository();
+        Deployment deployment = Deployment.builder()
+                .sourceRepository(repository)
+                .branchName("main")
+                .commitHash("abcdef1234567890")
+                .build();
+        DeploymentConfig config = DeploymentConfig.builder()
+                .sourceRepository(repository)
+                .minReplicas(1)
+                .maxReplicas(1)
+                .envVars(Map.of())
+                .containerPort(8080)
+                .domainUrl("iot.example.com")
+                .build();
+        String imageUri = "ghcr.io/kjhyeon0620/smart-sousvide-iot-platform/backend:sha-abcdef1234567890";
+        given(deploymentRepository.findById(1L)).willReturn(Optional.of(deployment));
+        given(deploymentConfigRepository.findBySourceRepositoryId(10L)).willReturn(Optional.of(config));
+        given(deploymentRepository.save(any(Deployment.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        stepService.executeK8sDeploy(1L, imageUri);
+
+        verify(k8sGenerator).deploy("kjhyeon0620-smart-sousvide-iot-platform", imageUri, config, 10L);
+        verify(k8sGenerator).waitForDeploymentAvailable("kjhyeon0620-smart-sousvide-iot-platform");
+    }
+
+    private SourceRepository repository() {
+        User user = User.builder()
+                .email("test@example.com")
+                .name("tester")
+                .role(Role.USER)
+                .providerId("12345")
+                .build();
+        SourceRepository repository = SourceRepository.builder()
+                .user(user)
+                .owner("kjhyeon0620")
+                .repoName("smart-sousvide-iot-platform")
+                .gitUrl("https://github.com/kjhyeon0620/smart-sousvide-iot-platform")
+                .cloudVendor(CloudVendor.ON_PREMISE)
+                .build();
+        ReflectionTestUtils.setField(repository, "id", 10L);
+        return repository;
+    }
+}

--- a/backend/src/test/java/klepaas/backend/deployment/service/ExternalImageResolverTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/service/ExternalImageResolverTest.java
@@ -1,0 +1,107 @@
+package klepaas.backend.deployment.service;
+
+import klepaas.backend.deployment.entity.BuildStrategy;
+import klepaas.backend.deployment.entity.CloudVendor;
+import klepaas.backend.deployment.entity.Deployment;
+import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.SourceRepository;
+import klepaas.backend.global.exception.BusinessException;
+import klepaas.backend.user.entity.Role;
+import klepaas.backend.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ExternalImageResolverTest {
+
+    private final ExternalImageResolver resolver = new ExternalImageResolver();
+
+    @Test
+    @DisplayName("요청 imageUri가 있으면 config 템플릿보다 우선한다")
+    void resolve_returnsRequestedImageUri_whenDeploymentAlreadyHasImageUri() {
+        // Given
+        Deployment deployment = deployment("abcdef1234567890");
+        deployment.setImageUri("ghcr.io/kjhyeon0620/smart-sousvide-iot-platform/backend:sha-abcdef1234567890");
+        DeploymentConfig config = config("ghcr.io/other/repo:sha-{commitHash}");
+
+        // When
+        String imageUri = resolver.resolve(deployment, config);
+
+        // Then
+        assertThat(imageUri)
+                .isEqualTo("ghcr.io/kjhyeon0620/smart-sousvide-iot-platform/backend:sha-abcdef1234567890");
+    }
+
+    @Test
+    @DisplayName("config 템플릿으로 commitHash와 shortCommitHash placeholder를 치환한다")
+    void resolve_replacesTemplatePlaceholders_whenTemplateIsConfigured() {
+        // Given
+        Deployment deployment = deployment("abcdef1234567890");
+        DeploymentConfig config = config("ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}-{shortCommitHash}");
+
+        // When
+        String imageUri = resolver.resolve(deployment, config);
+
+        // Then
+        assertThat(imageUri)
+                .isEqualTo("ghcr.io/kjhyeon0620/smart-sousvide-iot-platform/backend:sha-abcdef1234567890-abcdef1");
+    }
+
+    @Test
+    @DisplayName("외부 이미지 전략에서 HEAD는 명시 imageUri 없이 사용할 수 없다")
+    void resolve_throwsBusinessException_whenCommitHashIsHeadWithoutImageUri() {
+        // Given
+        Deployment deployment = deployment("HEAD");
+        DeploymentConfig config = config("ghcr.io/{owner}/{repoName}:sha-{commitHash}");
+
+        assertThatThrownBy(() -> resolver.resolve(deployment, config))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("외부 이미지 전략에서 imageUri와 템플릿이 모두 없으면 사용할 수 없다")
+    void resolve_throwsBusinessException_whenImageUriAndTemplateAreMissing() {
+        Deployment deployment = deployment("abcdef1234567890");
+        DeploymentConfig config = config(null);
+
+        assertThatThrownBy(() -> resolver.resolve(deployment, config))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    private Deployment deployment(String commitHash) {
+        User user = User.builder()
+                .email("test@example.com")
+                .name("tester")
+                .role(Role.USER)
+                .providerId("12345")
+                .build();
+        SourceRepository repository = SourceRepository.builder()
+                .user(user)
+                .owner("kjhyeon0620")
+                .repoName("smart-sousvide-iot-platform")
+                .gitUrl("https://github.com/kjhyeon0620/smart-sousvide-iot-platform")
+                .cloudVendor(CloudVendor.ON_PREMISE)
+                .build();
+        return Deployment.builder()
+                .sourceRepository(repository)
+                .branchName("main")
+                .commitHash(commitHash)
+                .build();
+    }
+
+    private DeploymentConfig config(String imageUriTemplate) {
+        return DeploymentConfig.builder()
+                .minReplicas(1)
+                .maxReplicas(1)
+                .envVars(Map.of())
+                .containerPort(8080)
+                .domainUrl("iot.example.com")
+                .buildStrategy(BuildStrategy.GITHUB_ACTIONS_GHCR)
+                .imageUriTemplate(imageUriTemplate)
+                .build();
+    }
+}

--- a/backend/src/test/java/klepaas/backend/deployment/service/RepositoryServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/service/RepositoryServiceTest.java
@@ -6,6 +6,7 @@ import klepaas.backend.deployment.dto.*;
 import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.CloudVendor;
 import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.KubernetesServiceType;
 import klepaas.backend.deployment.entity.SourceRepository;
 import klepaas.backend.deployment.repository.DeploymentConfigRepository;
 import klepaas.backend.deployment.repository.SourceRepositoryRepository;
@@ -13,6 +14,7 @@ import klepaas.backend.global.exception.DuplicateResourceException;
 import klepaas.backend.global.exception.EntityNotFoundException;
 import klepaas.backend.global.exception.GitHubAppInstallationRequiredException;
 import klepaas.backend.global.exception.GitHubAppNotInstalledException;
+import klepaas.backend.global.exception.InvalidRequestException;
 import klepaas.backend.user.entity.Role;
 import klepaas.backend.user.entity.User;
 import klepaas.backend.user.repository.UserRepository;
@@ -232,7 +234,9 @@ class RepositoryServiceTest {
                     "custom.klepaas.io",
                     BuildStrategy.GITHUB_ACTIONS_GHCR,
                     "ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}",
-                    "ghcr-pull-secret"
+                    "ghcr-pull-secret",
+                    KubernetesServiceType.NODE_PORT,
+                    30080
             );
             given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
             given(deploymentConfigRepository.findBySourceRepositoryId(1L))
@@ -247,6 +251,88 @@ class RepositoryServiceTest {
             assertThat(response.buildStrategy()).isEqualTo(BuildStrategy.GITHUB_ACTIONS_GHCR);
             assertThat(response.imageUriTemplate()).isEqualTo("ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}");
             assertThat(response.imagePullSecretName()).isEqualTo("ghcr-pull-secret");
+            assertThat(response.serviceType()).isEqualTo(KubernetesServiceType.NODE_PORT);
+            assertThat(response.nodePort()).isEqualTo(30080);
+        }
+
+        @Test
+        @DisplayName("실패: NODE_PORT 서비스는 nodePort가 필요하다")
+        void failNodePortServiceWithoutNodePort() {
+            var request = new UpdateDeploymentConfigRequest(
+                    2,
+                    5,
+                    Map.of("ENV", "prod"),
+                    3000,
+                    "custom.klepaas.io",
+                    BuildStrategy.GITHUB_ACTIONS_GHCR,
+                    "ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}",
+                    "ghcr-pull-secret",
+                    KubernetesServiceType.NODE_PORT,
+                    null
+            );
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+
+            assertThatThrownBy(() -> repositoryService.updateDeploymentConfig(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("nodePort");
+        }
+
+        @Test
+        @DisplayName("성공: CLUSTER_IP로 전환하면 기존 nodePort를 제거한다")
+        void successClearsNodePortWhenServiceTypeIsClusterIp() {
+            DeploymentConfig nodePortConfig = DeploymentConfig.builder()
+                    .sourceRepository(testRepo)
+                    .minReplicas(1)
+                    .maxReplicas(1)
+                    .envVars(Map.of())
+                    .containerPort(8080)
+                    .domainUrl("repo.klepaas.io")
+                    .serviceType(KubernetesServiceType.NODE_PORT)
+                    .nodePort(30080)
+                    .build();
+            var request = new UpdateDeploymentConfigRequest(
+                    1,
+                    1,
+                    Map.of(),
+                    8080,
+                    "repo.klepaas.io",
+                    null,
+                    null,
+                    null,
+                    KubernetesServiceType.CLUSTER_IP,
+                    null
+            );
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(nodePortConfig));
+
+            DeploymentConfigResponse response = repositoryService.updateDeploymentConfig(1L, request);
+
+            assertThat(response.serviceType()).isEqualTo(KubernetesServiceType.CLUSTER_IP);
+            assertThat(response.nodePort()).isNull();
+        }
+
+        @Test
+        @DisplayName("실패: CLUSTER_IP 서비스에는 nodePort를 설정할 수 없다")
+        void failClusterIpServiceWithNodePort() {
+            var request = new UpdateDeploymentConfigRequest(
+                    2,
+                    5,
+                    Map.of("ENV", "prod"),
+                    3000,
+                    "custom.klepaas.io",
+                    null,
+                    null,
+                    null,
+                    KubernetesServiceType.CLUSTER_IP,
+                    30080
+            );
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+
+            assertThatThrownBy(() -> repositoryService.updateDeploymentConfig(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("nodePort");
         }
 
         @Test
@@ -262,6 +348,8 @@ class RepositoryServiceTest {
                     .buildStrategy(BuildStrategy.GITHUB_ACTIONS_GHCR)
                     .imageUriTemplate("ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}")
                     .imagePullSecretName("ghcr-pull-secret")
+                    .serviceType(KubernetesServiceType.NODE_PORT)
+                    .nodePort(30080)
                     .build();
             var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "custom.klepaas.io");
             given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
@@ -272,6 +360,8 @@ class RepositoryServiceTest {
             assertThat(response.buildStrategy()).isEqualTo(BuildStrategy.GITHUB_ACTIONS_GHCR);
             assertThat(response.imageUriTemplate()).isEqualTo("ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}");
             assertThat(response.imagePullSecretName()).isEqualTo("ghcr-pull-secret");
+            assertThat(response.serviceType()).isEqualTo(KubernetesServiceType.NODE_PORT);
+            assertThat(response.nodePort()).isEqualTo(30080);
         }
     }
 }

--- a/backend/src/test/java/klepaas/backend/deployment/service/RepositoryServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/service/RepositoryServiceTest.java
@@ -3,6 +3,7 @@ package klepaas.backend.deployment.service;
 import klepaas.backend.auth.config.GitHubAppConfig;
 import klepaas.backend.auth.oauth.GitHubAppClient;
 import klepaas.backend.deployment.dto.*;
+import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.CloudVendor;
 import klepaas.backend.deployment.entity.DeploymentConfig;
 import klepaas.backend.deployment.entity.SourceRepository;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -105,6 +107,27 @@ class RepositoryServiceTest {
             assertThat(response.repoName()).isEqualTo("testrepo");
             assertThat(response.cloudVendor()).isEqualTo(CloudVendor.NCP);
             verify(deploymentConfigRepository).save(any(DeploymentConfig.class));
+        }
+
+        @Test
+        @DisplayName("성공: ON_PREMISE 저장소는 GitHub Actions GHCR 전략을 쓰되 이미지 템플릿은 명시 설정하게 둔다")
+        void successOnPremiseDefaultBuildStrategy() {
+            var request = new CreateRepositoryRequest("kjhyeon0620", "smart-sousvide-iot-platform",
+                    "https://github.com/kjhyeon0620/smart-sousvide-iot-platform", CloudVendor.ON_PREMISE);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("kjhyeon0620", "smart-sousvide-iot-platform"))
+                    .willReturn(Optional.empty());
+            given(gitHubAppClient.getInstallationId("kjhyeon0620", "smart-sousvide-iot-platform")).willReturn(123L);
+            given(sourceRepositoryRepository.save(any(SourceRepository.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deploymentConfigRepository.save(any(DeploymentConfig.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            repositoryService.createRepository(1L, request);
+
+            ArgumentCaptor<DeploymentConfig> configCaptor = ArgumentCaptor.forClass(DeploymentConfig.class);
+            verify(deploymentConfigRepository).save(configCaptor.capture());
+            DeploymentConfig savedConfig = configCaptor.getValue();
+            assertThat(savedConfig.getBuildStrategy()).isEqualTo(BuildStrategy.GITHUB_ACTIONS_GHCR);
+            assertThat(savedConfig.getImageUriTemplate()).isNull();
         }
 
         @Test
@@ -201,7 +224,16 @@ class RepositoryServiceTest {
         @Test
         @DisplayName("성공: 배포 설정 업데이트")
         void success() {
-            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "custom.klepaas.io");
+            var request = new UpdateDeploymentConfigRequest(
+                    2,
+                    5,
+                    Map.of("ENV", "prod"),
+                    3000,
+                    "custom.klepaas.io",
+                    BuildStrategy.GITHUB_ACTIONS_GHCR,
+                    "ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}",
+                    "ghcr-pull-secret"
+            );
             given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
             given(deploymentConfigRepository.findBySourceRepositoryId(1L))
                     .willReturn(Optional.of(testConfig));
@@ -212,6 +244,34 @@ class RepositoryServiceTest {
             assertThat(response.maxReplicas()).isEqualTo(5);
             assertThat(response.containerPort()).isEqualTo(3000);
             assertThat(response.domainUrl()).isEqualTo("custom.klepaas.io");
+            assertThat(response.buildStrategy()).isEqualTo(BuildStrategy.GITHUB_ACTIONS_GHCR);
+            assertThat(response.imageUriTemplate()).isEqualTo("ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}");
+            assertThat(response.imagePullSecretName()).isEqualTo("ghcr-pull-secret");
+        }
+
+        @Test
+        @DisplayName("성공: 새 build 설정 필드가 생략되면 기존 값을 유지")
+        void successPreservesBuildSettingsWhenRequestOmitsThem() {
+            DeploymentConfig onPremiseConfig = DeploymentConfig.builder()
+                    .sourceRepository(testRepo)
+                    .minReplicas(1)
+                    .maxReplicas(1)
+                    .envVars(Map.of())
+                    .containerPort(8080)
+                    .domainUrl("repo.klepaas.io")
+                    .buildStrategy(BuildStrategy.GITHUB_ACTIONS_GHCR)
+                    .imageUriTemplate("ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}")
+                    .imagePullSecretName("ghcr-pull-secret")
+                    .build();
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "custom.klepaas.io");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(onPremiseConfig));
+
+            DeploymentConfigResponse response = repositoryService.updateDeploymentConfig(1L, request);
+
+            assertThat(response.buildStrategy()).isEqualTo(BuildStrategy.GITHUB_ACTIONS_GHCR);
+            assertThat(response.imageUriTemplate()).isEqualTo("ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}");
+            assertThat(response.imagePullSecretName()).isEqualTo("ghcr-pull-secret");
         }
     }
 }

--- a/backend/src/test/java/klepaas/backend/infra/kubernetes/KubernetesManifestGeneratorTest.java
+++ b/backend/src/test/java/klepaas/backend/infra/kubernetes/KubernetesManifestGeneratorTest.java
@@ -1,0 +1,117 @@
+package klepaas.backend.infra.kubernetes;
+
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentConditionBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KubernetesManifestGeneratorTest {
+
+    private final KubernetesManifestGenerator generator =
+            new KubernetesManifestGenerator(Mockito.mock(KubernetesClient.class));
+
+    @Test
+    @DisplayName("새 generation이 관측되고 replica 카운터가 맞을 때 rollout 성공으로 본다")
+    void isDeploymentRolloutComplete_returnsTrueWhenObservedGenerationAndReplicasAreReady() {
+        var complete = new DeploymentBuilder()
+                .withNewMetadata()
+                .withGeneration(2L)
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(2)
+                .endSpec()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .withUpdatedReplicas(2)
+                .withAvailableReplicas(2)
+                .withUnavailableReplicas(0)
+                .withConditions(new DeploymentConditionBuilder()
+                        .withType("Available")
+                        .withStatus("True")
+                        .build())
+                .endStatus()
+                .build();
+
+        assertThat(generator.isDeploymentRolloutComplete(complete)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Available condition이 True여도 새 generation이 관측되지 않았으면 rollout 성공이 아니다")
+    void isDeploymentRolloutComplete_returnsFalseWhenObservedGenerationIsStale() {
+        var staleGeneration = new DeploymentBuilder()
+                .withNewMetadata()
+                .withGeneration(2L)
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(2)
+                .endSpec()
+                .withNewStatus()
+                .withObservedGeneration(1L)
+                .withUpdatedReplicas(2)
+                .withAvailableReplicas(2)
+                .withUnavailableReplicas(0)
+                .withConditions(new DeploymentConditionBuilder()
+                        .withType("Available")
+                        .withStatus("True")
+                        .build())
+                .endStatus()
+                .build();
+
+        assertThat(generator.isDeploymentRolloutComplete(staleGeneration)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Available condition이 True여도 updated replica가 부족하면 rollout 성공이 아니다")
+    void isDeploymentRolloutComplete_returnsFalseWhenUpdatedReplicasAreNotReady() {
+        var staleReplicaSet = new DeploymentBuilder()
+                .withNewMetadata()
+                .withGeneration(2L)
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(2)
+                .endSpec()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .withUpdatedReplicas(1)
+                .withAvailableReplicas(2)
+                .withUnavailableReplicas(0)
+                .withConditions(new DeploymentConditionBuilder()
+                        .withType("Available")
+                        .withStatus("True")
+                        .build())
+                .endStatus()
+                .build();
+
+        assertThat(generator.isDeploymentRolloutComplete(staleReplicaSet)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Available condition이 True여도 unavailable replica가 남아 있으면 rollout 성공이 아니다")
+    void isDeploymentRolloutComplete_returnsFalseWhenUnavailableReplicasRemain() {
+        var unavailable = new DeploymentBuilder()
+                .withNewMetadata()
+                .withGeneration(2L)
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(2)
+                .endSpec()
+                .withNewStatus()
+                .withObservedGeneration(2L)
+                .withUpdatedReplicas(2)
+                .withAvailableReplicas(1)
+                .withUnavailableReplicas(1)
+                .withConditions(new DeploymentConditionBuilder()
+                        .withType("Available")
+                        .withStatus("True")
+                        .build())
+                .endStatus()
+                .build();
+
+        assertThat(generator.isDeploymentRolloutComplete(unavailable)).isFalse();
+        assertThat(generator.isDeploymentRolloutComplete(null)).isFalse();
+    }
+}

--- a/backend/src/test/java/klepaas/backend/infra/kubernetes/KubernetesManifestGeneratorTest.java
+++ b/backend/src/test/java/klepaas/backend/infra/kubernetes/KubernetesManifestGeneratorTest.java
@@ -3,9 +3,13 @@ package klepaas.backend.infra.kubernetes;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentConditionBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.KubernetesServiceType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -113,5 +117,25 @@ class KubernetesManifestGeneratorTest {
 
         assertThat(generator.isDeploymentRolloutComplete(unavailable)).isFalse();
         assertThat(generator.isDeploymentRolloutComplete(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("NODE_PORT 서비스 포트에는 configured nodePort를 포함한다")
+    void buildServicePort_includesConfiguredNodePort_whenServiceTypeIsNodePort() {
+        DeploymentConfig config = DeploymentConfig.builder()
+                .minReplicas(1)
+                .maxReplicas(1)
+                .envVars(Map.of())
+                .containerPort(8080)
+                .domainUrl("iot.example.com")
+                .serviceType(KubernetesServiceType.NODE_PORT)
+                .nodePort(30080)
+                .build();
+
+        var servicePort = generator.buildServicePort(config);
+
+        assertThat(servicePort.getPort()).isEqualTo(80);
+        assertThat(servicePort.getTargetPort().getIntVal()).isEqualTo(8080);
+        assertThat(servicePort.getNodePort()).isEqualTo(30080);
     }
 }

--- a/backend/src/test/java/klepaas/backend/webhook/service/GitHubWebhookServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/webhook/service/GitHubWebhookServiceTest.java
@@ -1,0 +1,123 @@
+package klepaas.backend.webhook.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import klepaas.backend.deployment.entity.BuildStrategy;
+import klepaas.backend.deployment.entity.CloudVendor;
+import klepaas.backend.deployment.entity.DeploymentConfig;
+import klepaas.backend.deployment.entity.SourceRepository;
+import klepaas.backend.deployment.repository.DeploymentConfigRepository;
+import klepaas.backend.deployment.repository.SourceRepositoryRepository;
+import klepaas.backend.deployment.service.DeploymentService;
+import klepaas.backend.user.entity.Role;
+import klepaas.backend.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubWebhookServiceTest {
+
+    @Mock
+    private SourceRepositoryRepository sourceRepositoryRepository;
+
+    @Mock
+    private DeploymentConfigRepository deploymentConfigRepository;
+
+    @Mock
+    private DeploymentService deploymentService;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private GitHubWebhookService gitHubWebhookService;
+
+    @Test
+    @DisplayName("GITHUB_ACTIONS_GHCR 저장소는 raw push webhook에서 배포를 시작하지 않는다")
+    void handlePushEvent_skipsDeployment_whenRepositoryUsesGitHubActionsGhcr() throws Exception {
+        SourceRepository repository = repository(CloudVendor.ON_PREMISE);
+        DeploymentConfig config = DeploymentConfig.builder()
+                .sourceRepository(repository)
+                .minReplicas(1)
+                .maxReplicas(1)
+                .envVars(Map.of())
+                .containerPort(8080)
+                .domainUrl("iot.example.com")
+                .buildStrategy(BuildStrategy.GITHUB_ACTIONS_GHCR)
+                .imageUriTemplate("ghcr.io/{owner}/{repoName}/backend:sha-{commitHash}")
+                .build();
+        String payload = """
+                {
+                  "ref": "refs/heads/main",
+                  "after": "abcdef1234567890",
+                  "deleted": false,
+                  "repository": {
+                    "name": "smart-sousvide-iot-platform",
+                    "owner": {"login": "kjhyeon0620"}
+                  }
+                }
+                """;
+        given(sourceRepositoryRepository.findByOwnerAndRepoName("kjhyeon0620", "smart-sousvide-iot-platform"))
+                .willReturn(Optional.of(repository));
+        given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(config));
+
+        gitHubWebhookService.handlePushEvent(payload);
+
+        verify(deploymentService, never()).createDeployment(any(), any());
+    }
+
+    @Test
+    @DisplayName("ON_PREMISE 저장소는 배포 설정 조회가 실패해도 raw push webhook에서 배포를 시작하지 않는다")
+    void handlePushEvent_skipsDeployment_whenOnPremiseConfigIsMissing() throws Exception {
+        SourceRepository repository = repository(CloudVendor.ON_PREMISE);
+        String payload = """
+                {
+                  "ref": "refs/heads/main",
+                  "after": "abcdef1234567890",
+                  "deleted": false,
+                  "repository": {
+                    "name": "smart-sousvide-iot-platform",
+                    "owner": {"login": "kjhyeon0620"}
+                  }
+                }
+                """;
+        given(sourceRepositoryRepository.findByOwnerAndRepoName("kjhyeon0620", "smart-sousvide-iot-platform"))
+                .willReturn(Optional.of(repository));
+        given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.empty());
+
+        gitHubWebhookService.handlePushEvent(payload);
+
+        verify(deploymentService, never()).createDeployment(any(), any());
+    }
+
+    private SourceRepository repository(CloudVendor cloudVendor) {
+        User user = User.builder()
+                .email("test@example.com")
+                .name("tester")
+                .role(Role.USER)
+                .providerId("12345")
+                .build();
+        SourceRepository repository = SourceRepository.builder()
+                .user(user)
+                .owner("kjhyeon0620")
+                .repoName("smart-sousvide-iot-platform")
+                .gitUrl("https://github.com/kjhyeon0620/smart-sousvide-iot-platform")
+                .cloudVendor(cloudVendor)
+                .build();
+        ReflectionTestUtils.setField(repository, "id", 1L);
+        return repository;
+    }
+}

--- a/docs/ORACLE_K3S_GHCR_DEPLOYMENT.md
+++ b/docs/ORACLE_K3S_GHCR_DEPLOYMENT.md
@@ -1,0 +1,64 @@
+# Oracle k3s + GHCR Deployment MVP
+
+This document records the runtime assumptions for deploying an externally built
+GHCR image to an Oracle Free Tier k3s target through K-Le-PaaS.
+
+## Scope
+
+- K-Le-PaaS remains the deployment control plane.
+- GitHub Actions builds and pushes the linux/arm64 image to GHCR.
+- K-Le-PaaS resolves the image URI, applies Kubernetes resources, records status,
+  waits for the Kubernetes Deployment to become Available, and sends existing
+  deployment notifications.
+- The existing NCP path keeps using Kaniko and NCR.
+
+## Build Strategy Mapping
+
+| Cloud vendor | Build strategy | Image source |
+| --- | --- | --- |
+| `NCP` | `KANIKO` | NCR image produced by the existing Kaniko Job |
+| `ON_PREMISE` | `GITHUB_ACTIONS_GHCR` | GHCR image produced by GitHub Actions |
+
+`AWS` remains planned and is not opened by this MVP.
+
+## Oracle k3s Runtime Requirements
+
+- k3s is installed on the Oracle server.
+- K-Le-PaaS runs with a kubeconfig that can reach that k3s cluster.
+- `K8S_NAMESPACE` points to the target namespace.
+- A GHCR image pull secret exists in that namespace when the GHCR image is private.
+- Secrets such as kubeconfig, GHCR tokens, SSH keys, and production env vars must
+  stay outside Git.
+
+## Image URI Template
+
+`DeploymentConfig.imageUriTemplate` supports these placeholders:
+
+- `{owner}`
+- `{repoName}`
+- `{commitHash}`
+- `{shortCommitHash}`
+
+Example for the Smart Sousvide backend image:
+
+```text
+ghcr.io/kjhyeon0620/smart-sousvide-iot-platform/backend:sha-{commitHash}
+```
+
+If a deployment request provides `image_uri`, that explicit image URI is used
+instead of the template.
+
+For external image strategies, either `image_uri` or `imageUriTemplate` must be
+configured. K-Le-PaaS does not infer a default GHCR package path because package
+names can differ by repository, for example `repo:sha-...` versus
+`repo/backend:sha-...`.
+
+## Recommended Trigger
+
+Use GitHub Actions to call K-Le-PaaS after the GHCR push succeeds. A raw push
+webhook can arrive before the image exists, so it is not reliable enough for the
+Oracle GHCR path by itself.
+
+Raw GitHub push webhooks are ignored for repositories configured with
+`GITHUB_ACTIONS_GHCR` or `PREBUILT_IMAGE`. They remain valid for the existing
+`KANIKO` path.

--- a/docs/ORACLE_K3S_GHCR_DEPLOYMENT.md
+++ b/docs/ORACLE_K3S_GHCR_DEPLOYMENT.md
@@ -27,6 +27,8 @@ GHCR image to an Oracle Free Tier k3s target through K-Le-PaaS.
 - K-Le-PaaS runs with a kubeconfig that can reach that k3s cluster.
 - `K8S_NAMESPACE` points to the target namespace.
 - A GHCR image pull secret exists in that namespace when the GHCR image is private.
+- For the Oracle MVP, configure the service as `NODE_PORT` when host Nginx is
+  the public edge.
 - Secrets such as kubeconfig, GHCR tokens, SSH keys, and production env vars must
   stay outside Git.
 
@@ -48,7 +50,7 @@ ghcr.io/kjhyeon0620/smart-sousvide-iot-platform/backend:sha-{commitHash}
 If a deployment request provides `image_uri`, that explicit image URI is used
 instead of the template.
 
-For external image strategies, either `image_uri` or `imageUriTemplate` must be
+For external image strategies, either `image_uri` or `image_uri_template` must be
 configured. K-Le-PaaS does not infer a default GHCR package path because package
 names can differ by repository, for example `repo:sha-...` versus
 `repo/backend:sha-...`.
@@ -62,3 +64,20 @@ Oracle GHCR path by itself.
 Raw GitHub push webhooks are ignored for repositories configured with
 `GITHUB_ACTIONS_GHCR` or `PREBUILT_IMAGE`. They remain valid for the existing
 `KANIKO` path.
+
+## Service Exposure
+
+The default Kubernetes Service type remains `CLUSTER_IP`, preserving the existing
+NCP behavior. For Oracle single-node k3s behind host Nginx, set:
+
+```text
+service_type: NODE_PORT
+node_port: 30080
+container_port: 8080
+```
+
+Then route host Nginx to the selected node port, for example
+`http://127.0.0.1:30080`.
+
+`NODE_PORT` requires an explicit `node_port` so the host Nginx upstream remains
+stable. Switching back to `CLUSTER_IP` clears the stored `node_port`.


### PR DESCRIPTION
## 요약

- K-Le-PaaS가 Oracle Free Tier 단일 노드 k3s를 ON_PREMISE Kubernetes 배포 대상으로 다룰 수 있도록 확장했습니다.
- 기존 NCP 경로는 Kaniko/NCR/Kubernetes 흐름을 유지하고, Oracle 경로는 GitHub Actions + GHCR에서 준비된 이미지를 배포하는 방식으로 분리했습니다.
- 외부 이미지 배포에서도 rollout 완료 조건을 확인하고, NodePort 기반 host Nginx 연동 설정을 지원하도록 보강했습니다.

closed #33

## 변경 내용

- `BuildStrategy`를 추가해 `KANIKO`, `GITHUB_ACTIONS_GHCR`, `PREBUILT_IMAGE` 경로를 분리
- ON_PREMISE 저장소 기본 build strategy를 `GITHUB_ACTIONS_GHCR`로 설정
- GHCR 외부 이미지 경로에서 `image_uri` 또는 `image_uri_template` 기반 이미지 배포 지원
- `GITHUB_ACTIONS_GHCR`/`PREBUILT_IMAGE` 전략은 raw GitHub push webhook 자동 배포를 skip하도록 처리
- 외부 이미지 경로의 `BUILDING` 상태 전이와 외부 build id 기록 보강
- Kubernetes apply 후 rollout 완료 대기 추가
- rollout 성공 판정에 `observedGeneration`, `updatedReplicas`, `availableReplicas`, `unavailableReplicas`, `Available=True` 조건 반영
- Kubernetes Service type 설정 추가
  - 기본값: `CLUSTER_IP`
  - Oracle host Nginx 연동용: `NODE_PORT`
  - `NODE_PORT`는 `node_port` 필수
  - `CLUSTER_IP` 전환 시 기존 `node_port` 제거
- Oracle k3s/GHCR 배포 문서 추가 및 API snake_case 표기 정리

## 기대 효과

- K-Le-PaaS가 빌드 도구가 아니라 배포 결정, rollout, status, audit, notification을 담당하는 control plane 역할에 더 가까워집니다.
- NCP/Kaniko 경로를 깨지 않고 Oracle k3s/GHCR 경로를 MVP 수준으로 분리해 운영할 수 있습니다.
- GHCR 이미지가 없거나 pull secret이 틀린 경우에도 apply 성공만으로 배포 성공 처리하지 않고 rollout 상태를 확인합니다.

## 검증

- `./gradlew test --tests klepaas.backend.deployment.service.RepositoryServiceTest --tests klepaas.backend.infra.kubernetes.KubernetesManifestGeneratorTest`
- `./gradlew test --rerun-tasks`
- `git diff --check`

## 참고

- 실제 Oracle 서버 live rollout 검증은 k3s, GHCR secret, K-Le-PaaS backend 실행 환경 연결 후 별도 단계에서 진행합니다.
- production secret, kubeconfig, GHCR token, SSH key는 포함하지 않았습니다.