### PR TITLE
feat: 저장소 기본 배포 도메인 자동 생성

### DIFF
--- a/backend/src/main/java/klepaas/backend/deployment/dto/CreateRepositoryRequest.java
+++ b/backend/src/main/java/klepaas/backend/deployment/dto/CreateRepositoryRequest.java
@@ -8,6 +8,10 @@ public record CreateRepositoryRequest(
         @NotBlank String owner,
         @NotBlank String repoName,
         @NotBlank String gitUrl,
-        @NotNull CloudVendor cloudVendor
+        @NotNull CloudVendor cloudVendor,
+        String domainUrl
 ) {
+    public CreateRepositoryRequest(String owner, String repoName, String gitUrl, CloudVendor cloudVendor) {
+        this(owner, repoName, gitUrl, cloudVendor, null);
+    }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/entity/DeploymentConfig.java
+++ b/backend/src/main/java/klepaas/backend/deployment/entity/DeploymentConfig.java
@@ -14,7 +14,10 @@ import java.util.Map;
 
 @Entity
 @Getter
-@Table(name = "deployment_configs")
+@Table(
+        name = "deployment_configs",
+        uniqueConstraints = @UniqueConstraint(name = "uk_deployment_configs_domain_url", columnNames = "domain_url")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DeploymentConfig extends BaseTimeEntity {
 
@@ -37,7 +40,7 @@ public class DeploymentConfig extends BaseTimeEntity {
     @Column(nullable = false)
     private int containerPort;
 
-    @Column(nullable = false)
+    @Column(name = "domain_url", nullable = false)
     private String domainUrl;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/klepaas/backend/deployment/repository/DeploymentConfigRepository.java
+++ b/backend/src/main/java/klepaas/backend/deployment/repository/DeploymentConfigRepository.java
@@ -8,4 +8,8 @@ import java.util.Optional;
 public interface DeploymentConfigRepository extends JpaRepository<DeploymentConfig, Long> {
 
     Optional<DeploymentConfig> findBySourceRepositoryId(Long sourceRepositoryId);
+
+    boolean existsByDomainUrl(String domainUrl);
+
+    boolean existsByDomainUrlAndSourceRepositoryIdNot(String domainUrl, Long sourceRepositoryId);
 }

--- a/backend/src/main/java/klepaas/backend/deployment/service/RepositoryService.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/RepositoryService.java
@@ -20,11 +20,15 @@ import klepaas.backend.user.entity.User;
 import klepaas.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 @Service
@@ -38,6 +42,9 @@ public class RepositoryService {
     private final GitHubAppClient gitHubAppClient;
     private final GitHubAppConfig gitHubAppConfig;
 
+    @Value("${deployment.domain.suffix:klepaas.io}")
+    private String deploymentDomainSuffix = "klepaas.io";
+
     @Transactional
     public RepositoryResponse createRepository(Long userId, CreateRepositoryRequest request) {
         User user = userRepository.findById(userId)
@@ -47,6 +54,9 @@ public class RepositoryService {
                 .ifPresent(r -> {
                     throw new DuplicateResourceException(ErrorCode.REPOSITORY_ALREADY_EXISTS);
                 });
+
+        String domainUrl = resolveCreateDomainUrl(request);
+        validateDomainUrlAvailable(domainUrl);
 
         checkGitHubAppInstalled(request.owner(), request.repoName());
 
@@ -65,10 +75,10 @@ public class RepositoryService {
                 .maxReplicas(1)
                 .envVars(new HashMap<>())
                 .containerPort(8080)
-                .domainUrl(request.repoName() + ".klepaas.io")
+                .domainUrl(domainUrl)
                 .buildStrategy(defaultBuildStrategy(request.cloudVendor()))
                 .build();
-        deploymentConfigRepository.save(defaultConfig);
+        saveDeploymentConfig(defaultConfig);
 
         log.info("Repository created: {}/{} (id={})", request.owner(), request.repoName(), repository.getId());
         return RepositoryResponse.from(repository);
@@ -125,19 +135,21 @@ public class RepositoryService {
         DeploymentConfig config = deploymentConfigRepository.findBySourceRepositoryId(repositoryId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.DEPLOYMENT_CONFIG_NOT_FOUND));
 
+        String domainUrl = resolveUpdateDomainUrl(repositoryId, config, request.domainUrl());
         ServiceExposure serviceExposure = resolveServiceExposure(config, request);
         config.updateConfig(
                 request.minReplicas(),
                 request.maxReplicas(),
                 request.envVars(),
                 request.containerPort(),
-                request.domainUrl(),
+                domainUrl,
                 request.buildStrategy(),
                 request.imageUriTemplate(),
                 request.imagePullSecretName(),
                 serviceExposure.serviceType(),
                 serviceExposure.nodePort()
         );
+        flushDeploymentConfigChanges();
 
         log.info("DeploymentConfig updated: repositoryId={}", repositoryId);
         return DeploymentConfigResponse.from(config);
@@ -168,6 +180,129 @@ public class RepositoryService {
             case NCP, AWS -> BuildStrategy.KANIKO;
             case ON_PREMISE -> BuildStrategy.GITHUB_ACTIONS_GHCR;
         };
+    }
+
+    private String resolveCreateDomainUrl(CreateRepositoryRequest request) {
+        if (StringUtils.hasText(request.domainUrl())) {
+            return canonicalizeDomainHost(request.domainUrl(), "domain_url");
+        }
+        String suffix = canonicalizeDomainHost(normalizeDomainSuffix(), "DEPLOYMENT_DOMAIN_SUFFIX");
+        return canonicalizeDomainHost(normalizeRepoName(request.repoName()) + "." + suffix, "domain_url");
+    }
+
+    private String normalizeRepoName(String repoName) {
+        String normalized = repoName.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9-]", "-")
+                .replaceAll("-+", "-")
+                .replaceAll("^-+|-+$", "");
+        if (!StringUtils.hasText(normalized)) {
+            throw new InvalidRequestException(ErrorCode.INVALID_REQUEST, "repoName을 DNS-safe 도메인 이름으로 변환할 수 없습니다");
+        }
+        return normalized;
+    }
+
+    private String normalizeDomainSuffix() {
+        String suffix = deploymentDomainSuffix == null ? "" : deploymentDomainSuffix.trim();
+        if (!StringUtils.hasText(suffix)) {
+            throw new InvalidRequestException(ErrorCode.INVALID_REQUEST, "deployment domain suffix가 설정되지 않았습니다");
+        }
+        return suffix;
+    }
+
+    private void validateDomainUrlAvailable(String domainUrl) {
+        if (deploymentConfigRepository.existsByDomainUrl(domainUrl)) {
+            throw new DuplicateResourceException(ErrorCode.DUPLICATE_RESOURCE);
+        }
+    }
+
+    private void saveDeploymentConfig(DeploymentConfig config) {
+        try {
+            deploymentConfigRepository.save(config);
+            deploymentConfigRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throwDomainDuplicateIfApplicable(e);
+            throw e;
+        }
+    }
+
+    private void flushDeploymentConfigChanges() {
+        try {
+            deploymentConfigRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throwDomainDuplicateIfApplicable(e);
+            throw e;
+        }
+    }
+
+    private void throwDomainDuplicateIfApplicable(DataIntegrityViolationException exception) {
+        if (isDomainUrlIntegrityViolation(exception)) {
+            throw new DuplicateResourceException(ErrorCode.DUPLICATE_RESOURCE);
+        }
+    }
+
+    private boolean isDomainUrlIntegrityViolation(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null) {
+                String normalizedMessage = message.toLowerCase(Locale.ROOT);
+                if (normalizedMessage.contains("domain_url")
+                        || normalizedMessage.contains("domainurl")
+                        || normalizedMessage.contains("uk_deployment_configs_domain_url")) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private String resolveUpdateDomainUrl(Long repositoryId, DeploymentConfig config, String domainUrl) {
+        if (domainUrl == null) {
+            return config.getDomainUrl();
+        }
+
+        if (!StringUtils.hasText(domainUrl)) {
+            throw new InvalidRequestException(ErrorCode.INVALID_REQUEST, "domain_url은 비워둘 수 없습니다");
+        }
+
+        String canonicalDomainUrl = canonicalizeDomainHost(domainUrl, "domain_url");
+        if (deploymentConfigRepository.existsByDomainUrlAndSourceRepositoryIdNot(canonicalDomainUrl, repositoryId)) {
+            throw new DuplicateResourceException(ErrorCode.DUPLICATE_RESOURCE);
+        }
+        return canonicalDomainUrl;
+    }
+
+    private String canonicalizeDomainHost(String value, String fieldName) {
+        String host = value.trim().toLowerCase(Locale.ROOT);
+        if (!isValidDomainHost(host)) {
+            throw new InvalidRequestException(ErrorCode.INVALID_REQUEST, fieldName + "이 올바른 DNS host 형식이 아닙니다");
+        }
+        return host;
+    }
+
+    private boolean isValidDomainHost(String host) {
+        if (host.length() > 253 || host.startsWith(".") || host.endsWith(".")) {
+            return false;
+        }
+
+        String[] labels = host.split("\\.", -1);
+        if (labels.length < 2) {
+            return false;
+        }
+
+        for (String label : labels) {
+            if (!isValidDomainLabel(label)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isValidDomainLabel(String label) {
+        return !label.isBlank()
+                && label.length() <= 63
+                && label.matches("[a-z0-9]([a-z0-9-]*[a-z0-9])?");
     }
 
     private record ServiceExposure(KubernetesServiceType serviceType, Integer nodePort) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -77,6 +77,8 @@ slack:
     url: ${SLACK_WEBHOOK_URL:}
 
 deployment:
+  domain:
+    suffix: ${DEPLOYMENT_DOMAIN_SUFFIX:klepaas.io}
   pipeline:
     poll-initial-interval: 10000
     poll-max-interval: 60000

--- a/backend/src/test/java/klepaas/backend/deployment/controller/RepositoryControllerTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/controller/RepositoryControllerTest.java
@@ -6,6 +6,7 @@ import klepaas.backend.auth.config.SecurityConfig;
 import klepaas.backend.auth.jwt.JwtAuthenticationFilter;
 import klepaas.backend.auth.jwt.JwtTokenProvider;
 import klepaas.backend.auth.token.service.CliAccessTokenService;
+import klepaas.backend.deployment.dto.CreateRepositoryRequest;
 import klepaas.backend.deployment.dto.DeploymentConfigResponse;
 import klepaas.backend.deployment.dto.RepositoryResponse;
 import klepaas.backend.deployment.entity.CloudVendor;
@@ -14,6 +15,7 @@ import klepaas.backend.user.entity.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -27,9 +29,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -82,10 +86,15 @@ class RepositoryControllerTest {
                                 "owner", "owner",
                                 "repo_name", "repo",
                                 "git_url", "https://github.com/owner/repo",
-                                "cloud_vendor", "NCP"
+                                "cloud_vendor", "NCP",
+                                "domain_url", "custom.example.com"
                         ))))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.owner").value("owner"));
+
+        ArgumentCaptor<CreateRepositoryRequest> requestCaptor = ArgumentCaptor.forClass(CreateRepositoryRequest.class);
+        verify(repositoryService).createRepository(anyLong(), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().domainUrl()).isEqualTo("custom.example.com");
     }
 
     @Test

--- a/backend/src/test/java/klepaas/backend/deployment/service/RepositoryServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/service/RepositoryServiceTest.java
@@ -27,6 +27,8 @@ import org.mockito.InjectMocks;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -108,7 +111,122 @@ class RepositoryServiceTest {
             assertThat(response.owner()).isEqualTo("testowner");
             assertThat(response.repoName()).isEqualTo("testrepo");
             assertThat(response.cloudVendor()).isEqualTo(CloudVendor.NCP);
-            verify(deploymentConfigRepository).save(any(DeploymentConfig.class));
+            ArgumentCaptor<DeploymentConfig> configCaptor = ArgumentCaptor.forClass(DeploymentConfig.class);
+            verify(deploymentConfigRepository).save(configCaptor.capture());
+            assertThat(configCaptor.getValue().getDomainUrl()).isEqualTo("testrepo.klepaas.io");
+        }
+
+        @Test
+        @DisplayName("성공: 설정된 suffix로 기본 배포 도메인 생성")
+        void successDefaultDomainWithConfiguredSuffix() {
+            ReflectionTestUtils.setField(repositoryService, "deploymentDomainSuffix", "juhyeon.app");
+            var request = new CreateRepositoryRequest("kjhyeon0620", "smart-sousvide-iot-platform",
+                    "https://github.com/kjhyeon0620/smart-sousvide-iot-platform", CloudVendor.ON_PREMISE);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("kjhyeon0620", "smart-sousvide-iot-platform"))
+                    .willReturn(Optional.empty());
+            given(gitHubAppClient.getInstallationId("kjhyeon0620", "smart-sousvide-iot-platform")).willReturn(123L);
+            given(sourceRepositoryRepository.save(any(SourceRepository.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deploymentConfigRepository.save(any(DeploymentConfig.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            repositoryService.createRepository(1L, request);
+
+            ArgumentCaptor<DeploymentConfig> configCaptor = ArgumentCaptor.forClass(DeploymentConfig.class);
+            verify(deploymentConfigRepository).save(configCaptor.capture());
+            assertThat(configCaptor.getValue().getDomainUrl())
+                    .isEqualTo("smart-sousvide-iot-platform.juhyeon.app");
+        }
+
+        @Test
+        @DisplayName("성공: repoName을 DNS-safe하게 변환해 기본 도메인 생성")
+        void successNormalizesRepoNameForDefaultDomain() {
+            var request = new CreateRepositoryRequest("testowner", "Smart_Sousvide IoT.Platform",
+                    "https://github.com/testowner/Smart_Sousvide IoT.Platform", CloudVendor.NCP);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "Smart_Sousvide IoT.Platform"))
+                    .willReturn(Optional.empty());
+            given(gitHubAppClient.getInstallationId("testowner", "Smart_Sousvide IoT.Platform")).willReturn(123L);
+            given(sourceRepositoryRepository.save(any(SourceRepository.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deploymentConfigRepository.save(any(DeploymentConfig.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            repositoryService.createRepository(1L, request);
+
+            ArgumentCaptor<DeploymentConfig> configCaptor = ArgumentCaptor.forClass(DeploymentConfig.class);
+            verify(deploymentConfigRepository).save(configCaptor.capture());
+            assertThat(configCaptor.getValue().getDomainUrl())
+                    .isEqualTo("smart-sousvide-iot-platform.klepaas.io");
+        }
+
+        @Test
+        @DisplayName("성공: custom domain_url을 우선 사용")
+        void successUsesCustomDomainUrl() {
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP, "custom.example.com");
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+            given(gitHubAppClient.getInstallationId("testowner", "testrepo")).willReturn(123L);
+            given(sourceRepositoryRepository.save(any(SourceRepository.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deploymentConfigRepository.save(any(DeploymentConfig.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            repositoryService.createRepository(1L, request);
+
+            ArgumentCaptor<DeploymentConfig> configCaptor = ArgumentCaptor.forClass(DeploymentConfig.class);
+            verify(deploymentConfigRepository).save(configCaptor.capture());
+            assertThat(configCaptor.getValue().getDomainUrl()).isEqualTo("custom.example.com");
+        }
+
+        @Test
+        @DisplayName("성공: custom domain_url은 lowercase canonical 값으로 저장")
+        void successCanonicalizesCustomDomainUrl() {
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP, "Custom.Example.COM");
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+            given(gitHubAppClient.getInstallationId("testowner", "testrepo")).willReturn(123L);
+            given(sourceRepositoryRepository.save(any(SourceRepository.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deploymentConfigRepository.save(any(DeploymentConfig.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            repositoryService.createRepository(1L, request);
+
+            ArgumentCaptor<DeploymentConfig> configCaptor = ArgumentCaptor.forClass(DeploymentConfig.class);
+            verify(deploymentConfigRepository).existsByDomainUrl("custom.example.com");
+            verify(deploymentConfigRepository).save(configCaptor.capture());
+            assertThat(configCaptor.getValue().getDomainUrl()).isEqualTo("custom.example.com");
+        }
+
+        @Test
+        @DisplayName("성공: custom domain_url이 blank면 기본 도메인 사용")
+        void successBlankCustomDomainFallsBackToDefaultDomain() {
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP, " ");
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+            given(gitHubAppClient.getInstallationId("testowner", "testrepo")).willReturn(123L);
+            given(sourceRepositoryRepository.save(any(SourceRepository.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deploymentConfigRepository.save(any(DeploymentConfig.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            repositoryService.createRepository(1L, request);
+
+            ArgumentCaptor<DeploymentConfig> configCaptor = ArgumentCaptor.forClass(DeploymentConfig.class);
+            verify(deploymentConfigRepository).save(configCaptor.capture());
+            assertThat(configCaptor.getValue().getDomainUrl()).isEqualTo("testrepo.klepaas.io");
+        }
+
+        @Test
+        @DisplayName("실패: custom domain_url이 DNS host 형식이 아니면 거절")
+        void failInvalidCustomDomainUrl() {
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP, "https://example.com");
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("domain_url");
         }
 
         @Test
@@ -162,6 +280,113 @@ class RepositoryServiceTest {
 
             assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
                     .isInstanceOf(DuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 기본 domain_url이 이미 사용 중")
+        void failDuplicateDefaultDomainUrl() {
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+            given(deploymentConfigRepository.existsByDomainUrl("testrepo.klepaas.io")).willReturn(true);
+
+            assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
+                    .isInstanceOf(DuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("실패: custom domain_url이 이미 사용 중")
+        void failDuplicateCustomDomainUrl() {
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP, "custom.example.com");
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+            given(deploymentConfigRepository.existsByDomainUrl("custom.example.com")).willReturn(true);
+
+            assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
+                    .isInstanceOf(DuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("실패: DB unique 제약으로 domain_url 중복이 감지되면 409 예외로 변환")
+        void failDuplicateDomainUrlOnFlush() {
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+            given(gitHubAppClient.getInstallationId("testowner", "testrepo")).willReturn(123L);
+            given(sourceRepositoryRepository.save(any(SourceRepository.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deploymentConfigRepository.save(any(DeploymentConfig.class))).willAnswer(invocation -> invocation.getArgument(0));
+            willThrow(new DataIntegrityViolationException("domain_url")).given(deploymentConfigRepository).flush();
+
+            assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
+                    .isInstanceOf(DuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("실패: domain_url과 무관한 DB 제약 위반은 원 예외를 유지")
+        void failNonDomainIntegrityViolationKeepsOriginalException() {
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+            given(gitHubAppClient.getInstallationId("testowner", "testrepo")).willReturn(123L);
+            given(sourceRepositoryRepository.save(any(SourceRepository.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deploymentConfigRepository.save(any(DeploymentConfig.class))).willAnswer(invocation -> invocation.getArgument(0));
+            willThrow(new DataIntegrityViolationException("other_constraint"))
+                    .given(deploymentConfigRepository).flush();
+
+            assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("실패: repoName 정규화 결과가 비어 있음")
+        void failBlankNormalizedRepoName() {
+            var request = new CreateRepositoryRequest("testowner", "___",
+                    "https://github.com/testowner/___", CloudVendor.NCP);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "___"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("repoName");
+        }
+
+        @Test
+        @DisplayName("실패: 기본 도메인의 repoName label이 63자를 초과하면 거절")
+        void failDefaultDomainWithTooLongRepoLabel() {
+            String repoName = "a".repeat(64);
+            var request = new CreateRepositoryRequest("testowner", repoName,
+                    "https://github.com/testowner/" + repoName, CloudVendor.NCP);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", repoName))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("domain_url");
+        }
+
+        @Test
+        @DisplayName("실패: 설정된 suffix가 DNS host 형식이 아니면 거절")
+        void failInvalidDeploymentDomainSuffix() {
+            ReflectionTestUtils.setField(repositoryService, "deploymentDomainSuffix", ".juhyeon.app");
+            var request = new CreateRepositoryRequest("testowner", "testrepo",
+                    "https://github.com/testowner/testrepo", CloudVendor.NCP);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(sourceRepositoryRepository.findByOwnerAndRepoName("testowner", "testrepo"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> repositoryService.createRepository(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("DEPLOYMENT_DOMAIN_SUFFIX");
         }
 
         @Test
@@ -362,6 +587,107 @@ class RepositoryServiceTest {
             assertThat(response.imagePullSecretName()).isEqualTo("ghcr-pull-secret");
             assertThat(response.serviceType()).isEqualTo(KubernetesServiceType.NODE_PORT);
             assertThat(response.nodePort()).isEqualTo(30080);
+        }
+
+        @Test
+        @DisplayName("성공: 자기 자신의 기존 domain_url은 유지 가능")
+        void successAllowsOwnDomainUrl() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "testrepo.klepaas.io");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+            given(deploymentConfigRepository.existsByDomainUrlAndSourceRepositoryIdNot("testrepo.klepaas.io", 1L))
+                    .willReturn(false);
+
+            DeploymentConfigResponse response = repositoryService.updateDeploymentConfig(1L, request);
+
+            assertThat(response.domainUrl()).isEqualTo("testrepo.klepaas.io");
+        }
+
+        @Test
+        @DisplayName("성공: domain_url을 생략하면 기존 domain_url을 유지")
+        void successPreservesDomainUrlWhenRequestOmitsIt() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, null);
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+
+            DeploymentConfigResponse response = repositoryService.updateDeploymentConfig(1L, request);
+
+            assertThat(response.domainUrl()).isEqualTo("testrepo.klepaas.io");
+        }
+
+        @Test
+        @DisplayName("성공: 수정 domain_url은 lowercase canonical 값으로 저장")
+        void successCanonicalizesDomainUrlOnUpdate() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "Custom.KLEPAAS.IO");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+
+            DeploymentConfigResponse response = repositoryService.updateDeploymentConfig(1L, request);
+
+            verify(deploymentConfigRepository).existsByDomainUrlAndSourceRepositoryIdNot("custom.klepaas.io", 1L);
+            assertThat(response.domainUrl()).isEqualTo("custom.klepaas.io");
+        }
+
+        @Test
+        @DisplayName("실패: 다른 저장소의 domain_url로 수정할 수 없다")
+        void failDuplicateDomainUrlOnUpdate() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "custom.klepaas.io");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+            given(deploymentConfigRepository.existsByDomainUrlAndSourceRepositoryIdNot("custom.klepaas.io", 1L))
+                    .willReturn(true);
+
+            assertThatThrownBy(() -> repositoryService.updateDeploymentConfig(1L, request))
+                    .isInstanceOf(DuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 수정 중 DB unique 제약으로 domain_url 중복이 감지되면 409 예외로 변환")
+        void failDuplicateDomainUrlOnUpdateFlush() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "custom.klepaas.io");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+            willThrow(new DataIntegrityViolationException("domain_url")).given(deploymentConfigRepository).flush();
+
+            assertThatThrownBy(() -> repositoryService.updateDeploymentConfig(1L, request))
+                    .isInstanceOf(DuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 수정 중 domain_url과 무관한 DB 제약 위반은 원 예외를 유지")
+        void failNonDomainIntegrityViolationOnUpdateKeepsOriginalException() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "custom.klepaas.io");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+            willThrow(new DataIntegrityViolationException("other_constraint"))
+                    .given(deploymentConfigRepository).flush();
+
+            assertThatThrownBy(() -> repositoryService.updateDeploymentConfig(1L, request))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 수정 domain_url이 DNS host 형식이 아니면 거절")
+        void failInvalidDomainUrlOnUpdate() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "repo..klepaas.io");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+
+            assertThatThrownBy(() -> repositoryService.updateDeploymentConfig(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("domain_url");
+        }
+
+        @Test
+        @DisplayName("실패: blank domain_url로 수정할 수 없다")
+        void failBlankDomainUrlOnUpdate() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, " ");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+
+            assertThatThrownBy(() -> repositoryService.updateDeploymentConfig(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("domain_url");
         }
     }
 }

--- a/docs/ORACLE_K3S_GHCR_DEPLOYMENT.md
+++ b/docs/ORACLE_K3S_GHCR_DEPLOYMENT.md
@@ -81,3 +81,39 @@ Then route host Nginx to the selected node port, for example
 
 `NODE_PORT` requires an explicit `node_port` so the host Nginx upstream remains
 stable. Switching back to `CLUSTER_IP` clears the stored `node_port`.
+
+## Default Deployment Domain
+
+When a repository is registered without a custom `domain_url`, K-Le-PaaS creates
+a default deployment domain from the repository name:
+
+```text
+{repo_name}.{DEPLOYMENT_DOMAIN_SUFFIX}
+```
+
+`repo_name` is normalized for DNS use before the domain is stored: lowercase
+letters, numbers, and `-` are kept; other characters become `-`; repeated `-`
+characters are collapsed; leading and trailing `-` characters are removed.
+
+The default suffix is:
+
+```text
+DEPLOYMENT_DOMAIN_SUFFIX=klepaas.io
+```
+
+For the Oracle server, set:
+
+```text
+DEPLOYMENT_DOMAIN_SUFFIX=juhyeon.app
+```
+
+Example:
+
+```text
+smart-sousvide-iot-platform.juhyeon.app
+```
+
+If a repository create request includes `domain_url`, that custom value is used
+instead. `domain_url` must be unique across repositories. When a default or
+custom domain is already in use, K-Le-PaaS rejects the request instead of adding
+suffixes such as `-2` or `-3`; set a different custom `domain_url` explicitly.


### PR DESCRIPTION
## 요약

- 저장소 등록 시 배포 기본 도메인을 자동 생성하도록 추가했습니다.
- 기본 도메인은 `{repo_name}.{DEPLOYMENT_DOMAIN_SUFFIX}` 형식을 사용합니다.
- 사용자가 `domain_url`을 직접 지정하면 custom domain을 우선 사용합니다.

closed #35

## 변경 내용

- `DEPLOYMENT_DOMAIN_SUFFIX` 설정 추가
  - 기본값: `klepaas.io`
  - Oracle 환경 예: `juhyeon.app`
- `CreateRepositoryRequest`에 optional `domain_url` 추가
- repo name을 DNS-safe label로 정규화해 기본 도메인 생성
- custom/default domain을 DNS host 형식으로 검증하고 lowercase canonical 값으로 저장
- 생성/수정 시 `domain_url` 중복 검증 추가
- `DeploymentConfig.domain_url`에 명시적 unique constraint 추가
- DB unique conflict가 domain URL 충돌일 때 `DuplicateResourceException`으로 변환
- config update에서 `domain_url`이 생략되면 기존 값을 유지하고, blank 값은 거절
- Oracle k3s/GHCR 문서에 기본 도메인 규칙 추가

## 기대 효과

- 사용자가 저장소를 등록할 때 별도 도메인을 입력하지 않아도 일관된 기본 배포 도메인을 갖습니다.
- Oracle 환경에서는 `DEPLOYMENT_DOMAIN_SUFFIX=juhyeon.app`만 설정하면 `{repo_name}.juhyeon.app` 형태의 도메인을 자동 생성할 수 있습니다.
- 도메인 중복과 invalid host를 저장 전에 막아 Kubernetes Ingress/route 실패 가능성을 줄입니다.

## 검증

- `bash ./gradlew test --tests klepaas.backend.deployment.service.RepositoryServiceTest`
- `bash ./gradlew test --tests klepaas.backend.deployment.controller.RepositoryControllerTest`
- `bash ./gradlew test --rerun-tasks`
- `git diff --check`

## 참고

- 이 프로젝트는 별도 migration 파일 없이 JPA schema update에 기대는 구조입니다. 운영 DB 배포 시 `domain_url` unique constraint가 실제 반영됐는지 확인이 필요합니다.
- production secret, kubeconfig, GHCR token, SSH key는 포함하지 않았습니다.