### PR TITLE
fix: support GitHub App private key formats

### DIFF
--- a/backend/src/main/java/klepaas/backend/auth/oauth/GitHubAppJwtProvider.java
+++ b/backend/src/main/java/klepaas/backend/auth/oauth/GitHubAppJwtProvider.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.security.KeyFactory;
+import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -40,17 +43,122 @@ public class GitHubAppJwtProvider {
     }
 
     private RSAPrivateKey parsePrivateKey(String pem) {
-        String cleanPem = pem
-                .replace("-----BEGIN PRIVATE KEY-----", "")
-                .replace("-----END PRIVATE KEY-----", "")
-                .replaceAll("\\s", "");
-        byte[] decoded = Base64.getDecoder().decode(cleanPem);
         try {
-            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
-            return (RSAPrivateKey) keyFactory.generatePrivate(keySpec);
+            String normalizedPem = normalizePrivateKey(pem);
+            boolean pkcs1RsaKey = normalizedPem.contains("-----BEGIN RSA PRIVATE KEY-----");
+            byte[] decoded = Base64.getDecoder().decode(stripPemMarkers(normalizedPem));
+            if (pkcs1RsaKey) {
+                return generateRsaPrivateKey(wrapPkcs1RsaKey(decoded));
+            }
+
+            return generatePkcs8OrPkcs1PrivateKey(decoded);
         } catch (Exception e) {
             throw new IllegalStateException("GitHub App private key 파싱 실패", e);
         }
+    }
+
+    private RSAPrivateKey generatePkcs8OrPkcs1PrivateKey(byte[] decoded) throws Exception {
+        try {
+            return generateRsaPrivateKey(decoded);
+        } catch (Exception pkcs8Exception) {
+            try {
+                return generateRsaPrivateKey(wrapPkcs1RsaKey(decoded));
+            } catch (Exception pkcs1Exception) {
+                pkcs8Exception.addSuppressed(pkcs1Exception);
+                throw pkcs8Exception;
+            }
+        }
+    }
+
+    private RSAPrivateKey generateRsaPrivateKey(byte[] keyBytes) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+        PrivateKey privateKey = keyFactory.generatePrivate(keySpec);
+        if (privateKey instanceof RSAPrivateKey rsaPrivateKey) {
+            return rsaPrivateKey;
+        }
+        throw new IllegalStateException("RSA private key가 아닙니다");
+    }
+
+    private String normalizePrivateKey(String pem) {
+        if (pem == null || pem.isBlank()) {
+            throw new IllegalStateException("GitHub App private key가 설정되지 않았습니다");
+        }
+        String normalized = pem.trim();
+        if ((normalized.startsWith("\"") && normalized.endsWith("\""))
+                || (normalized.startsWith("'") && normalized.endsWith("'"))) {
+            normalized = normalized.substring(1, normalized.length() - 1).trim();
+        }
+        return normalized
+                .replace("\\r\\n", "\n")
+                .replace("\\n", "\n")
+                .replace("\\r", "\n");
+    }
+
+    private String stripPemMarkers(String pem) {
+        return pem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replace("-----BEGIN RSA PRIVATE KEY-----", "")
+                .replace("-----END RSA PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+    }
+
+    private byte[] wrapPkcs1RsaKey(byte[] pkcs1Key) {
+        byte[] version = new byte[]{0x02, 0x01, 0x00};
+        byte[] rsaEncryptionAlgorithmIdentifier = new byte[]{
+                0x30, 0x0d,
+                0x06, 0x09,
+                0x2a, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xf7, 0x0d, 0x01, 0x01, 0x01,
+                0x05, 0x00
+        };
+        return derSequence(concat(
+                version,
+                rsaEncryptionAlgorithmIdentifier,
+                derOctetString(pkcs1Key)
+        ));
+    }
+
+    private byte[] derSequence(byte[] value) {
+        return concat(new byte[]{0x30}, derLength(value.length), value);
+    }
+
+    private byte[] derOctetString(byte[] value) {
+        return concat(new byte[]{0x04}, derLength(value.length), value);
+    }
+
+    private byte[] derLength(int length) {
+        if (length < 0x80) {
+            return new byte[]{(byte) length};
+        }
+
+        List<Byte> bytes = new ArrayList<>();
+        int remaining = length;
+        while (remaining > 0) {
+            bytes.add(0, (byte) (remaining & 0xff));
+            remaining >>= 8;
+        }
+
+        byte[] result = new byte[bytes.size() + 1];
+        result[0] = (byte) (0x80 | bytes.size());
+        for (int i = 0; i < bytes.size(); i++) {
+            result[i + 1] = bytes.get(i);
+        }
+        return result;
+    }
+
+    private byte[] concat(byte[]... arrays) {
+        int totalLength = 0;
+        for (byte[] array : arrays) {
+            totalLength += array.length;
+        }
+
+        byte[] result = new byte[totalLength];
+        int offset = 0;
+        for (byte[] array : arrays) {
+            System.arraycopy(array, 0, result, offset, array.length);
+            offset += array.length;
+        }
+        return result;
     }
 }

--- a/backend/src/test/java/klepaas/backend/auth/oauth/GitHubAppJwtProviderTest.java
+++ b/backend/src/test/java/klepaas/backend/auth/oauth/GitHubAppJwtProviderTest.java
@@ -1,0 +1,164 @@
+package klepaas.backend.auth.oauth;
+
+import klepaas.backend.auth.config.GitHubAppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GitHubAppJwtProviderTest {
+
+    private static RSAPrivateCrtKey privateKey;
+
+    @BeforeAll
+    static void generateKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        privateKey = (RSAPrivateCrtKey) keyPair.getPrivate();
+    }
+
+    @Test
+    @DisplayName("PKCS#8 PEM private key로 GitHub App JWT를 생성한다")
+    void generateAppJwt_supportsPkcs8Pem() {
+        GitHubAppJwtProvider provider = provider(pkcs8Pem());
+
+        String jwt = provider.generateAppJwt();
+
+        assertThat(jwt.split("\\.")).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("literal newline escape가 포함된 PEM private key로 GitHub App JWT를 생성한다")
+    void generateAppJwt_supportsEscapedNewlinePem() {
+        GitHubAppJwtProvider provider = provider(pkcs8Pem().replace("\n", "\\n"));
+
+        String jwt = provider.generateAppJwt();
+
+        assertThat(jwt.split("\\.")).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("PKCS#1 RSA PEM private key로 GitHub App JWT를 생성한다")
+    void generateAppJwt_supportsPkcs1RsaPem() {
+        GitHubAppJwtProvider provider = provider(pkcs1RsaPem());
+
+        String jwt = provider.generateAppJwt();
+
+        assertThat(jwt.split("\\.")).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("PEM marker가 없는 PKCS#1 RSA private key 본문으로 GitHub App JWT를 생성한다")
+    void generateAppJwt_supportsPkcs1RsaBodyOnly() {
+        GitHubAppJwtProvider provider = provider(base64Body(pkcs1RsaDer()));
+
+        String jwt = provider.generateAppJwt();
+
+        assertThat(jwt.split("\\.")).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("잘못된 private key는 명확한 파싱 오류를 던진다")
+    void generateAppJwt_throwsWhenPrivateKeyIsInvalid() {
+        GitHubAppJwtProvider provider = provider("not-a-private-key");
+
+        assertThatThrownBy(provider::generateAppJwt)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("GitHub App private key 파싱 실패");
+    }
+
+    private GitHubAppJwtProvider provider(String privateKeyPem) {
+        GitHubAppConfig config = new GitHubAppConfig();
+        config.setAppId(12345L);
+        config.setPrivateKey(privateKeyPem);
+        return new GitHubAppJwtProvider(config);
+    }
+
+    private String pkcs8Pem() {
+        return pem("PRIVATE KEY", privateKey.getEncoded());
+    }
+
+    private String pkcs1RsaPem() {
+        return pem("RSA PRIVATE KEY", pkcs1RsaDer());
+    }
+
+    private byte[] pkcs1RsaDer() {
+        return derSequence(concat(
+                derInteger(BigInteger.ZERO),
+                derInteger(privateKey.getModulus()),
+                derInteger(privateKey.getPublicExponent()),
+                derInteger(privateKey.getPrivateExponent()),
+                derInteger(privateKey.getPrimeP()),
+                derInteger(privateKey.getPrimeQ()),
+                derInteger(privateKey.getPrimeExponentP()),
+                derInteger(privateKey.getPrimeExponentQ()),
+                derInteger(privateKey.getCrtCoefficient())
+        ));
+    }
+
+    private String pem(String marker, byte[] der) {
+        return "-----BEGIN " + marker + "-----\n"
+                + base64Body(der)
+                + "\n-----END " + marker + "-----";
+    }
+
+    private String base64Body(byte[] der) {
+        return Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.US_ASCII))
+                .encodeToString(der);
+    }
+
+    private byte[] derInteger(BigInteger value) {
+        return concat(new byte[]{0x02}, derLength(value.toByteArray().length), value.toByteArray());
+    }
+
+    private byte[] derSequence(byte[] value) {
+        return concat(new byte[]{0x30}, derLength(value.length), value);
+    }
+
+    private byte[] derLength(int length) {
+        if (length < 0x80) {
+            return new byte[]{(byte) length};
+        }
+
+        List<Byte> bytes = new ArrayList<>();
+        int remaining = length;
+        while (remaining > 0) {
+            bytes.add(0, (byte) (remaining & 0xff));
+            remaining >>= 8;
+        }
+
+        byte[] result = new byte[bytes.size() + 1];
+        result[0] = (byte) (0x80 | bytes.size());
+        for (int i = 0; i < bytes.size(); i++) {
+            result[i + 1] = bytes.get(i);
+        }
+        return result;
+    }
+
+    private byte[] concat(byte[]... arrays) {
+        int totalLength = 0;
+        for (byte[] array : arrays) {
+            totalLength += array.length;
+        }
+
+        byte[] result = new byte[totalLength];
+        int offset = 0;
+        for (byte[] array : arrays) {
+            System.arraycopy(array, 0, result, offset, array.length);
+            offset += array.length;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- normalize GitHub App private key values from environment input, including quoted values and literal newline escapes
- support PKCS#8 `BEGIN PRIVATE KEY`, PKCS#1 `BEGIN RSA PRIVATE KEY`, and base64 body-only private key inputs
- add focused JWT provider tests for supported formats and invalid key handling

## Why
Oracle host repository connection failed while creating a GitHub App JWT because the runtime key format did not match the parser's narrow PKCS#8 expectation.

## Verification
- `./gradlew test --tests klepaas.backend.auth.oauth.GitHubAppJwtProviderTest --tests klepaas.backend.deployment.service.RepositoryServiceTest`
- `./gradlew test`
- `git diff --check`

Closes #39
