### PR TITLE
feat: support envFrom deployment config

### DIFF
--- a/backend/src/main/java/klepaas/backend/deployment/dto/DeploymentConfigResponse.java
+++ b/backend/src/main/java/klepaas/backend/deployment/dto/DeploymentConfigResponse.java
@@ -4,6 +4,7 @@ import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.DeploymentConfig;
 import klepaas.backend.deployment.entity.KubernetesServiceType;
 
+import java.util.List;
 import java.util.Map;
 
 public record DeploymentConfigResponse(
@@ -12,6 +13,8 @@ public record DeploymentConfigResponse(
         int minReplicas,
         int maxReplicas,
         Map<String, String> envVars,
+        List<String> envFromConfigMaps,
+        List<String> envFromSecrets,
         int containerPort,
         String domainUrl,
         BuildStrategy buildStrategy,
@@ -22,7 +25,7 @@ public record DeploymentConfigResponse(
 ) {
     public DeploymentConfigResponse(Long id, Long repositoryId, int minReplicas, int maxReplicas,
                                     Map<String, String> envVars, int containerPort, String domainUrl) {
-        this(id, repositoryId, minReplicas, maxReplicas, envVars, containerPort, domainUrl,
+        this(id, repositoryId, minReplicas, maxReplicas, envVars, List.of(), List.of(), containerPort, domainUrl,
                 BuildStrategy.KANIKO, null, null, KubernetesServiceType.CLUSTER_IP, null);
     }
 
@@ -33,6 +36,8 @@ public record DeploymentConfigResponse(
                 entity.getMinReplicas(),
                 entity.getMaxReplicas(),
                 entity.getEnvVars(),
+                entity.getEnvFromConfigMaps(),
+                entity.getEnvFromSecrets(),
                 entity.getContainerPort(),
                 entity.getDomainUrl(),
                 entity.getBuildStrategy(),

--- a/backend/src/main/java/klepaas/backend/deployment/dto/UpdateDeploymentConfigRequest.java
+++ b/backend/src/main/java/klepaas/backend/deployment/dto/UpdateDeploymentConfigRequest.java
@@ -5,12 +5,15 @@ import jakarta.validation.constraints.Max;
 import klepaas.backend.deployment.entity.BuildStrategy;
 import klepaas.backend.deployment.entity.KubernetesServiceType;
 
+import java.util.List;
 import java.util.Map;
 
 public record UpdateDeploymentConfigRequest(
         @Min(0) int minReplicas,
         @Min(1) int maxReplicas,
         Map<String, String> envVars,
+        List<String> envFromConfigMaps,
+        List<String> envFromSecrets,
         @Min(1) int containerPort,
         String domainUrl,
         BuildStrategy buildStrategy,
@@ -21,6 +24,16 @@ public record UpdateDeploymentConfigRequest(
 ) {
     public UpdateDeploymentConfigRequest(int minReplicas, int maxReplicas, Map<String, String> envVars,
                                          int containerPort, String domainUrl) {
-        this(minReplicas, maxReplicas, envVars, containerPort, domainUrl, null, null, null, null, null);
+        this(minReplicas, maxReplicas, envVars, null, null, containerPort, domainUrl,
+                null, null, null, null, null);
+    }
+
+    public UpdateDeploymentConfigRequest(int minReplicas, int maxReplicas, Map<String, String> envVars,
+                                         int containerPort, String domainUrl,
+                                         BuildStrategy buildStrategy, String imageUriTemplate,
+                                         String imagePullSecretName, KubernetesServiceType serviceType,
+                                         Integer nodePort) {
+        this(minReplicas, maxReplicas, envVars, null, null, containerPort, domainUrl,
+                buildStrategy, imageUriTemplate, imagePullSecretName, serviceType, nodePort);
     }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/entity/DeploymentConfig.java
+++ b/backend/src/main/java/klepaas/backend/deployment/entity/DeploymentConfig.java
@@ -9,7 +9,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 
 @Entity
@@ -37,6 +40,14 @@ public class DeploymentConfig extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private Map<String, String> envVars = new HashMap<>();
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "TEXT")
+    private List<String> envFromConfigMaps = new ArrayList<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "TEXT")
+    private List<String> envFromSecrets = new ArrayList<>();
+
     @Column(nullable = false)
     private int containerPort;
 
@@ -59,11 +70,14 @@ public class DeploymentConfig extends BaseTimeEntity {
     public DeploymentConfig(SourceRepository sourceRepository, int minReplicas, int maxReplicas,
                             Map<String, String> envVars, int containerPort, String domainUrl,
                             BuildStrategy buildStrategy, String imageUriTemplate, String imagePullSecretName,
-                            KubernetesServiceType serviceType, Integer nodePort) {
+                            KubernetesServiceType serviceType, Integer nodePort,
+                            List<String> envFromConfigMaps, List<String> envFromSecrets) {
         this.sourceRepository = sourceRepository;
         this.minReplicas = minReplicas;
         this.maxReplicas = maxReplicas;
         this.envVars = envVars != null ? envVars : new HashMap<>();
+        this.envFromConfigMaps = normalizeEnvFromRefs(envFromConfigMaps);
+        this.envFromSecrets = normalizeEnvFromRefs(envFromSecrets);
         this.containerPort = containerPort > 0 ? containerPort : 8080;
         this.domainUrl = domainUrl;
         this.buildStrategy = buildStrategy != null ? buildStrategy : BuildStrategy.KANIKO;
@@ -83,10 +97,13 @@ public class DeploymentConfig extends BaseTimeEntity {
 
     public void updateConfig(int min, int max, Map<String, String> envVars, int containerPort, String domainUrl,
                              BuildStrategy buildStrategy, String imageUriTemplate, String imagePullSecretName,
-                             KubernetesServiceType serviceType, Integer nodePort) {
+                             KubernetesServiceType serviceType, Integer nodePort,
+                             List<String> envFromConfigMaps, List<String> envFromSecrets) {
         this.minReplicas = min;
         this.maxReplicas = max;
         this.envVars = envVars != null ? envVars : new HashMap<>();
+        this.envFromConfigMaps = normalizeEnvFromRefs(envFromConfigMaps);
+        this.envFromSecrets = normalizeEnvFromRefs(envFromSecrets);
         this.containerPort = containerPort > 0 ? containerPort : 8080;
         this.domainUrl = domainUrl;
         this.buildStrategy = buildStrategy != null ? buildStrategy : getBuildStrategy();
@@ -94,5 +111,18 @@ public class DeploymentConfig extends BaseTimeEntity {
         this.imagePullSecretName = imagePullSecretName != null ? imagePullSecretName : this.imagePullSecretName;
         this.serviceType = serviceType != null ? serviceType : getServiceType();
         this.nodePort = nodePort;
+    }
+
+    private List<String> normalizeEnvFromRefs(List<String> names) {
+        if (names == null) {
+            return new ArrayList<>();
+        }
+        LinkedHashSet<String> normalizedNames = new LinkedHashSet<>();
+        for (String name : names) {
+            if (name != null && !name.isBlank()) {
+                normalizedNames.add(name.trim());
+            }
+        }
+        return new ArrayList<>(normalizedNames);
     }
 }

--- a/backend/src/main/java/klepaas/backend/deployment/service/RepositoryService.java
+++ b/backend/src/main/java/klepaas/backend/deployment/service/RepositoryService.java
@@ -26,7 +26,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 
@@ -137,6 +139,8 @@ public class RepositoryService {
 
         String domainUrl = resolveUpdateDomainUrl(repositoryId, config, request.domainUrl());
         ServiceExposure serviceExposure = resolveServiceExposure(config, request);
+        List<String> envFromConfigMaps = normalizeEnvFromRefs(request.envFromConfigMaps(), "env_from_config_maps");
+        List<String> envFromSecrets = normalizeEnvFromRefs(request.envFromSecrets(), "env_from_secrets");
         config.updateConfig(
                 request.minReplicas(),
                 request.maxReplicas(),
@@ -147,7 +151,9 @@ public class RepositoryService {
                 request.imageUriTemplate(),
                 request.imagePullSecretName(),
                 serviceExposure.serviceType(),
-                serviceExposure.nodePort()
+                serviceExposure.nodePort(),
+                envFromConfigMaps,
+                envFromSecrets
         );
         flushDeploymentConfigChanges();
 
@@ -303,6 +309,40 @@ public class RepositoryService {
         return !label.isBlank()
                 && label.length() <= 63
                 && label.matches("[a-z0-9]([a-z0-9-]*[a-z0-9])?");
+    }
+
+    private List<String> normalizeEnvFromRefs(List<String> names, String fieldName) {
+        if (names == null) {
+            return List.of();
+        }
+        LinkedHashSet<String> normalizedNames = new LinkedHashSet<>();
+        for (String name : names) {
+            if (name == null || name.isBlank()) {
+                continue;
+            }
+            String normalizedName = name.trim();
+            if (!isValidKubernetesObjectName(normalizedName)) {
+                throw new InvalidRequestException(
+                        ErrorCode.INVALID_REQUEST,
+                        fieldName + "에는 올바른 Kubernetes ConfigMap/Secret 이름만 사용할 수 있습니다: " + normalizedName
+                );
+            }
+            normalizedNames.add(normalizedName);
+        }
+        return new ArrayList<>(normalizedNames);
+    }
+
+    private boolean isValidKubernetesObjectName(String name) {
+        if (name.length() > 253 || name.startsWith(".") || name.endsWith(".")) {
+            return false;
+        }
+        String[] labels = name.split("\\.", -1);
+        for (String label : labels) {
+            if (!isValidDomainLabel(label)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private record ServiceExposure(KubernetesServiceType serviceType, Integer nodePort) {

--- a/backend/src/main/java/klepaas/backend/infra/kubernetes/KubernetesManifestGenerator.java
+++ b/backend/src/main/java/klepaas/backend/infra/kubernetes/KubernetesManifestGenerator.java
@@ -51,6 +51,7 @@ public class KubernetesManifestGenerator {
         );
 
         try {
+            validateEnvFromRefs(config);
             createOrUpdateDeployment(appName, imageUri, config, labels);
             createOrUpdateService(appName, config, labels);
 
@@ -59,6 +60,8 @@ public class KubernetesManifestGenerator {
             }
 
             log.info("K8s resources deployed: app={}, namespace={}", appName, namespace);
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             log.error("K8s deployment failed: app={}, error={}", appName, e.getMessage(), e);
             throw new BusinessException(ErrorCode.DEPLOY_FAILED, "K8s 배포 실패: " + e.getMessage());
@@ -141,11 +144,22 @@ public class KubernetesManifestGenerator {
 
     private void createOrUpdateDeployment(String appName, String imageUri,
                                            DeploymentConfig config, Map<String, String> labels) {
+        Deployment deployment = buildDeployment(appName, imageUri, config, labels);
+
+        kubernetesClient.apps().deployments()
+                .inNamespace(namespace)
+                .resource(deployment)
+                .serverSideApply();
+    }
+
+    Deployment buildDeployment(String appName, String imageUri,
+                               DeploymentConfig config, Map<String, String> labels) {
         List<EnvVar> envVars = config.getEnvVars().entrySet().stream()
                 .map(e -> new EnvVarBuilder().withName(e.getKey()).withValue(e.getValue()).build())
                 .collect(Collectors.toList());
+        List<EnvFromSource> envFromSources = buildEnvFromSources(config);
 
-        Deployment deployment = new DeploymentBuilder()
+        return new DeploymentBuilder()
                 .withNewMetadata()
                     .withName(appName)
                     .withNamespace(namespace)
@@ -171,16 +185,65 @@ public class KubernetesManifestGenerator {
                                             .withContainerPort(config.getContainerPort())
                                             .build())
                                     .withEnv(envVars)
+                                    .withEnvFrom(envFromSources)
                                     .build())
                         .endSpec()
                     .endTemplate()
                 .endSpec()
                 .build();
+    }
 
-        kubernetesClient.apps().deployments()
+    private List<EnvFromSource> buildEnvFromSources(DeploymentConfig config) {
+        List<EnvFromSource> envFromSources = config.getEnvFromConfigMaps().stream()
+                .map(name -> new EnvFromSourceBuilder()
+                        .withConfigMapRef(new ConfigMapEnvSourceBuilder().withName(name).build())
+                        .build())
+                .collect(Collectors.toList());
+        envFromSources.addAll(config.getEnvFromSecrets().stream()
+                .map(name -> new EnvFromSourceBuilder()
+                        .withSecretRef(new SecretEnvSourceBuilder().withName(name).build())
+                        .build())
+                .toList());
+        return envFromSources;
+    }
+
+    void validateEnvFromRefs(DeploymentConfig config) {
+        config.getEnvFromConfigMaps().forEach(this::validateConfigMapExists);
+        config.getEnvFromSecrets().forEach(this::validateSecretExists);
+    }
+
+    private void validateConfigMapExists(String name) {
+        if (!configMapExists(name)) {
+            throw new BusinessException(
+                    ErrorCode.DEPLOY_FAILED,
+                    "K8s envFrom ConfigMap을 찾을 수 없습니다: namespace=" + namespace + ", name=" + name
+            );
+        }
+    }
+
+    private void validateSecretExists(String name) {
+        if (!secretExists(name)) {
+            throw new BusinessException(
+                    ErrorCode.DEPLOY_FAILED,
+                    "K8s envFrom Secret을 찾을 수 없습니다: namespace=" + namespace + ", name=" + name
+            );
+        }
+    }
+
+    boolean configMapExists(String name) {
+        ConfigMap configMap = kubernetesClient.configMaps()
                 .inNamespace(namespace)
-                .resource(deployment)
-                .serverSideApply();
+                .withName(name)
+                .get();
+        return configMap != null;
+    }
+
+    boolean secretExists(String name) {
+        Secret secret = kubernetesClient.secrets()
+                .inNamespace(namespace)
+                .withName(name)
+                .get();
+        return secret != null;
     }
 
     private String resolveImagePullSecretName(DeploymentConfig config) {

--- a/backend/src/test/java/klepaas/backend/deployment/controller/RepositoryControllerTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/controller/RepositoryControllerTest.java
@@ -120,20 +120,25 @@ class RepositoryControllerTest {
     @Test
     @DisplayName("GET /api/v1/repositories/{id}/config - 배포 설정 조회")
     void getDeploymentConfig() throws Exception {
-        var config = new DeploymentConfigResponse(1L, 1L, 1, 3, Map.of(), 8080, "repo.klepaas.io");
+        var config = new DeploymentConfigResponse(1L, 1L, 1, 3, Map.of(), List.of("runtime-config"),
+                List.of("app-env"), 8080, "repo.klepaas.io", null, null, null, null, null);
         given(repositoryService.getDeploymentConfig(1L)).willReturn(config);
 
         mockMvc.perform(get("/api/v1/repositories/1/config")
                         .with(user(testUser)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.container_port").value(8080))
-                .andExpect(jsonPath("$.data.domain_url").value("repo.klepaas.io"));
+                .andExpect(jsonPath("$.data.domain_url").value("repo.klepaas.io"))
+                .andExpect(jsonPath("$.data.env_from_config_maps[0]").value("runtime-config"))
+                .andExpect(jsonPath("$.data.env_from_secrets[0]").value("app-env"));
     }
 
     @Test
     @DisplayName("PUT /api/v1/repositories/{id}/config - 배포 설정 수정")
     void updateDeploymentConfig() throws Exception {
-        var updatedConfig = new DeploymentConfigResponse(1L, 1L, 2, 5, Map.of("ENV", "prod"), 3000, "custom.klepaas.io");
+        var updatedConfig = new DeploymentConfigResponse(1L, 1L, 2, 5, Map.of("ENV", "prod"),
+                List.of("runtime-config"), List.of("app-env"), 3000, "custom.klepaas.io",
+                null, null, null, null, null);
         given(repositoryService.updateDeploymentConfig(anyLong(), any())).willReturn(updatedConfig);
 
         mockMvc.perform(put("/api/v1/repositories/1/config")
@@ -143,12 +148,16 @@ class RepositoryControllerTest {
                                 "min_replicas", 2,
                                 "max_replicas", 5,
                                 "env_vars", Map.of("ENV", "prod"),
+                                "env_from_config_maps", List.of("runtime-config"),
+                                "env_from_secrets", List.of("app-env"),
                                 "container_port", 3000,
                                 "domain_url", "custom.klepaas.io"
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.min_replicas").value(2))
-                .andExpect(jsonPath("$.data.container_port").value(3000));
+                .andExpect(jsonPath("$.data.container_port").value(3000))
+                .andExpect(jsonPath("$.data.env_from_config_maps[0]").value("runtime-config"))
+                .andExpect(jsonPath("$.data.env_from_secrets[0]").value("app-env"));
     }
 
     @Test

--- a/backend/src/test/java/klepaas/backend/deployment/service/RepositoryServiceTest.java
+++ b/backend/src/test/java/klepaas/backend/deployment/service/RepositoryServiceTest.java
@@ -455,6 +455,8 @@ class RepositoryServiceTest {
                     2,
                     5,
                     Map.of("ENV", "prod"),
+                    List.of("smart-sousvide-runtime-config", "smart-sousvide-runtime-config"),
+                    List.of("smart-sousvide-app-env"),
                     3000,
                     "custom.klepaas.io",
                     BuildStrategy.GITHUB_ACTIONS_GHCR,
@@ -478,6 +480,47 @@ class RepositoryServiceTest {
             assertThat(response.imagePullSecretName()).isEqualTo("ghcr-pull-secret");
             assertThat(response.serviceType()).isEqualTo(KubernetesServiceType.NODE_PORT);
             assertThat(response.nodePort()).isEqualTo(30080);
+            assertThat(response.envFromConfigMaps()).containsExactly("smart-sousvide-runtime-config");
+            assertThat(response.envFromSecrets()).containsExactly("smart-sousvide-app-env");
+        }
+
+        @Test
+        @DisplayName("성공: envFrom 목록이 null이면 빈 목록으로 저장한다")
+        void successTreatsNullEnvFromRefsAsEmptyLists() {
+            var request = new UpdateDeploymentConfigRequest(2, 5, Map.of("ENV", "prod"), 3000, "custom.klepaas.io");
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+
+            DeploymentConfigResponse response = repositoryService.updateDeploymentConfig(1L, request);
+
+            assertThat(response.envFromConfigMaps()).isEmpty();
+            assertThat(response.envFromSecrets()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("실패: Kubernetes 이름 형식이 아닌 envFrom 참조는 거절한다")
+        void failInvalidEnvFromRefName() {
+            var request = new UpdateDeploymentConfigRequest(
+                    2,
+                    5,
+                    Map.of("ENV", "prod"),
+                    List.of("Invalid_Name"),
+                    List.of(),
+                    3000,
+                    "custom.klepaas.io",
+                    null,
+                    null,
+                    null,
+                    KubernetesServiceType.CLUSTER_IP,
+                    null
+            );
+            given(sourceRepositoryRepository.findById(1L)).willReturn(Optional.of(testRepo));
+            given(deploymentConfigRepository.findBySourceRepositoryId(1L)).willReturn(Optional.of(testConfig));
+
+            assertThatThrownBy(() -> repositoryService.updateDeploymentConfig(1L, request))
+                    .isInstanceOf(InvalidRequestException.class)
+                    .hasMessageContaining("env_from_config_maps")
+                    .hasMessageContaining("Invalid_Name");
         }
 
         @Test

--- a/backend/src/test/java/klepaas/backend/infra/kubernetes/KubernetesManifestGeneratorTest.java
+++ b/backend/src/test/java/klepaas/backend/infra/kubernetes/KubernetesManifestGeneratorTest.java
@@ -5,13 +5,17 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentConditionBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import klepaas.backend.deployment.entity.DeploymentConfig;
 import klepaas.backend.deployment.entity.KubernetesServiceType;
+import klepaas.backend.global.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KubernetesManifestGeneratorTest {
 
@@ -137,5 +141,66 @@ class KubernetesManifestGeneratorTest {
         assertThat(servicePort.getPort()).isEqualTo(80);
         assertThat(servicePort.getTargetPort().getIntVal()).isEqualTo(8080);
         assertThat(servicePort.getNodePort()).isEqualTo(30080);
+    }
+
+    @Test
+    @DisplayName("Deployment manifest에는 envVars와 envFrom ConfigMap/Secret 참조를 함께 포함한다")
+    void buildDeployment_includesEnvVarsAndEnvFromSources() {
+        DeploymentConfig config = DeploymentConfig.builder()
+                .minReplicas(1)
+                .maxReplicas(1)
+                .envVars(Map.of("ENV", "prod"))
+                .envFromConfigMaps(List.of("smart-sousvide-runtime-config"))
+                .envFromSecrets(List.of("smart-sousvide-app-env"))
+                .containerPort(3000)
+                .domainUrl("iot.example.com")
+                .imagePullSecretName("ghcr-pull-secret")
+                .serviceType(KubernetesServiceType.NODE_PORT)
+                .nodePort(30080)
+                .build();
+        ReflectionTestUtils.setField(generator, "namespace", "klepaas");
+
+        var deployment = generator.buildDeployment("smart-sousvide", "ghcr.io/app:sha", config,
+                Map.of("app.kubernetes.io/name", "smart-sousvide"));
+
+        var podSpec = deployment.getSpec().getTemplate().getSpec();
+        var container = podSpec.getContainers().get(0);
+        assertThat(podSpec.getImagePullSecrets().get(0).getName()).isEqualTo("ghcr-pull-secret");
+        assertThat(container.getPorts().get(0).getContainerPort()).isEqualTo(3000);
+        assertThat(container.getEnv())
+                .anySatisfy(env -> {
+                    assertThat(env.getName()).isEqualTo("ENV");
+                    assertThat(env.getValue()).isEqualTo("prod");
+                });
+        assertThat(container.getEnvFrom()).hasSize(2);
+        assertThat(container.getEnvFrom().get(0).getConfigMapRef().getName())
+                .isEqualTo("smart-sousvide-runtime-config");
+        assertThat(container.getEnvFrom().get(1).getSecretRef().getName())
+                .isEqualTo("smart-sousvide-app-env");
+    }
+
+    @Test
+    @DisplayName("envFrom ConfigMap이 namespace에 없으면 명확한 배포 오류를 반환한다")
+    void validateEnvFromRefs_failsWhenConfigMapIsMissing() {
+        KubernetesManifestGenerator missingRefGenerator = new KubernetesManifestGenerator(Mockito.mock(KubernetesClient.class)) {
+            @Override
+            boolean configMapExists(String name) {
+                return false;
+            }
+        };
+        ReflectionTestUtils.setField(missingRefGenerator, "namespace", "klepaas");
+        DeploymentConfig config = DeploymentConfig.builder()
+                .minReplicas(1)
+                .maxReplicas(1)
+                .envVars(Map.of())
+                .envFromConfigMaps(List.of("missing-runtime-config"))
+                .containerPort(8080)
+                .domainUrl("iot.example.com")
+                .build();
+
+        assertThatThrownBy(() -> missingRefGenerator.validateEnvFromRefs(config))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("ConfigMap")
+                .hasMessageContaining("missing-runtime-config");
     }
 }

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -1,0 +1,77 @@
+# K-Le-PaaS Frontend Design System
+
+## 1. Atmosphere & Identity
+
+K-Le-PaaS is a quiet operations console for deployment work. The signature is dense but readable infrastructure state: cards, dialogs, tabs, badges, and forms use restrained spacing and familiar controls so repeated deployment tasks stay predictable.
+
+## 2. Color
+
+The app uses the Tailwind/shadcn semantic token set from `app/globals.css`: `background`, `foreground`, `card`, `card-foreground`, `muted`, `muted-foreground`, `border`, `input`, `ring`, `primary`, `primary-foreground`, `secondary`, `accent`, and `destructive`.
+
+Rules:
+- Use semantic utility classes such as `text-muted-foreground`, `border`, `bg-card`, and `bg-transparent`.
+- Status color utilities already present in the app may be used for deployment state badges.
+- Do not add secret-specific colors or decorative color ramps for configuration forms.
+
+## 3. Typography
+
+Font stack:
+- Primary: Geist Sans via `app/layout.tsx`
+- Mono: Geist Mono via `app/layout.tsx`
+
+Scale:
+- Page and card titles use existing shadcn `CardTitle` sizing.
+- Dialog and compact panel headings use `text-base` or existing component defaults.
+- Form helper text uses `text-xs` or `text-sm` with `text-muted-foreground`.
+- Monospace content such as image URLs, namespaces, and Kubernetes resource names uses `font-mono text-sm`.
+
+## 4. Spacing & Layout
+
+Base unit: 4px.
+
+Rules:
+- Compact forms use `space-y-2`, `space-y-3`, or `space-y-4`.
+- Dialog sections use existing `Card` blocks and `CardContent className="space-y-3"`.
+- Inline action groups use `gap-2`.
+- Do not introduce nested cards; existing cards represent individual settings or information groups.
+
+## 5. Components
+
+### Cards
+- Structure: `Card`, `CardHeader`, `CardTitle`, optional `CardDescription`, `CardContent`.
+- States: default only unless the card itself is interactive.
+- Accessibility: titles describe the contained setting group.
+
+### Dialog Tabs
+- Structure: `DialogContent` with `Tabs`, `TabsList`, and `TabsContent`.
+- States: tab focus and selection are handled by Radix/shadcn.
+- Accessibility: tabs must have concise labels and keep content reachable by keyboard.
+
+### Text Inputs And Textareas
+- Structure: `Label`, `Input` or `Textarea`, optional helper text.
+- Variants: single-line for scalar settings, textarea for comma-separated name lists.
+- States: default, focus, disabled, error via existing shadcn styling.
+- Accessibility: every field has a visible `Label`; helper copy must not include secret values.
+
+### Icon Buttons
+- Structure: `Button` with a Lucide icon when an existing command has an icon.
+- States: hover, active, focus, disabled via shadcn.
+- Accessibility: icon-only controls need accessible labels; text buttons can use visible text.
+
+## 6. Motion & Interaction
+
+Use existing Radix/shadcn interaction behavior. New settings work should avoid decorative animation and rely on button loading/disabled states when saving.
+
+## 7. Depth & Surface
+
+Strategy: borders with subtle shadows from the existing shadcn component classes. New controls must reuse existing `Card`, `Dialog`, `Input`, `Textarea`, and `Button` primitives.
+
+## 8. Accessibility Constraints & Accepted Debt
+
+Constraints:
+- WCAG 2.2 AA target for contrast and keyboard reachability.
+- Secret values are never displayed or requested; only Kubernetes Secret names can appear.
+- Configuration forms must keep labels visible and avoid placeholder-only instructions.
+
+Accepted debt:
+- No primitive showcase exists yet for the inherited UI system; this change documents the current system and keeps additions inside existing primitives.

--- a/frontend/components/deployment-status-monitoring.tsx
+++ b/frontend/components/deployment-status-monitoring.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import {
   Dialog,
   DialogContent,
@@ -32,9 +34,11 @@ import {
   Activity,
   ExternalLink,
   Terminal,
+  Save,
 } from "lucide-react"
-import { api } from "@/lib/api"
+import { api, type DeploymentConfigResponse } from "@/lib/api"
 import { useAuth } from "@/contexts/auth-context"
+import { useToast } from "@/hooks/use-toast"
 import { RollbackDialog } from "@/components/rollback-dialog"
 import { ScaleDialog } from "@/components/scale-dialog"
 import { RestartDialog } from "@/components/restart-dialog"
@@ -88,6 +92,15 @@ interface DeploymentStatusMonitoringProps {
   onNavigateToPipelines?: () => void
 }
 
+function parseEnvFromNames(value: string): string[] {
+  const names = value
+    .split(/[,\n]/)
+    .map((name) => name.trim())
+    .filter(Boolean)
+
+  return Array.from(new Set(names))
+}
+
 export function DeploymentStatusMonitoring({
   onNavigateToMonitoring,
   onNavigateToPipelines
@@ -96,7 +109,10 @@ export function DeploymentStatusMonitoring({
   const [loading, setLoading] = useState(true)
   const [selectedRepo, setSelectedRepo] = useState<RepositoryWorkload | null>(null)
   const [detailsOpen, setDetailsOpen] = useState(false)
-  const [deploymentConfigs, setDeploymentConfigs] = useState<Record<string, { replica_count: number }>>({})
+  const [deploymentConfigs, setDeploymentConfigs] = useState<Record<string, DeploymentConfigResponse>>({})
+  const [envFromConfigMapsInput, setEnvFromConfigMapsInput] = useState("")
+  const [envFromSecretsInput, setEnvFromSecretsInput] = useState("")
+  const [configSaving, setConfigSaving] = useState(false)
 
   // Dialog states for Rollback, Scale, Restart, Logs
   const [rollbackDialogOpen, setRollbackDialogOpen] = useState(false)
@@ -107,6 +123,7 @@ export function DeploymentStatusMonitoring({
 
   // 사용자 인증 상태 확인
   const { user, isLoading: authLoading } = useAuth()
+  const { toast } = useToast()
 
   const fetchRepositories = async () => {
     try {
@@ -115,16 +132,27 @@ export function DeploymentStatusMonitoring({
       setRepositories(response.repositories)
 
       // Fetch deployment configs for each repository
-      const configs: Record<string, { replica_count: number }> = {}
+      const configs: Record<string, DeploymentConfigResponse> = {}
       await Promise.all(
         response.repositories.map(async (repo: RepositoryWorkload) => {
           try {
             const config = await api.getDeploymentConfig(repo.owner, repo.repo)
-            configs[repo.full_name] = { replica_count: config.replica_count }
+            configs[repo.full_name] = config
           } catch (error) {
             console.error(`Failed to fetch config for ${repo.full_name}:`, error)
             // Use default replica count if config fetch fails
-            configs[repo.full_name] = { replica_count: 1 }
+            configs[repo.full_name] = {
+              owner: repo.owner,
+              repo: repo.repo,
+              min_replicas: 1,
+              max_replicas: 1,
+              replica_count: 1,
+              env_vars: {},
+              env_from_config_maps: [],
+              env_from_secrets: [],
+              container_port: 8080,
+              domain_url: null,
+            }
           }
         })
       )
@@ -142,6 +170,15 @@ export function DeploymentStatusMonitoring({
     const interval = setInterval(fetchRepositories, 30000)
     return () => clearInterval(interval)
   }, [])
+
+  useEffect(() => {
+    if (!selectedRepo || !detailsOpen) {
+      return
+    }
+    const config = deploymentConfigs[selectedRepo.full_name]
+    setEnvFromConfigMapsInput(config?.env_from_config_maps.join(", ") ?? "")
+    setEnvFromSecretsInput(config?.env_from_secrets.join(", ") ?? "")
+  }, [deploymentConfigs, detailsOpen, selectedRepo])
 
   const getStatusBadge = (status: string | undefined) => {
     if (!status) {
@@ -227,6 +264,41 @@ export function DeploymentStatusMonitoring({
   const handleActionSuccess = () => {
     // Refresh repositories after successful action
     fetchRepositories()
+  }
+
+  const handleSaveRuntimeEnvFrom = async () => {
+    if (!selectedRepo) {
+      return
+    }
+
+    try {
+      setConfigSaving(true)
+      const envFromConfigMaps = parseEnvFromNames(envFromConfigMapsInput)
+      const envFromSecrets = parseEnvFromNames(envFromSecretsInput)
+      const updatedConfig = await api.updateDeploymentRuntimeEnvFrom(
+        selectedRepo.owner,
+        selectedRepo.repo,
+        envFromConfigMaps,
+        envFromSecrets
+      )
+      setDeploymentConfigs((current) => ({
+        ...current,
+        [selectedRepo.full_name]: updatedConfig,
+      }))
+      toast({
+        title: "Runtime envFrom saved",
+        description: "ConfigMap and Secret names will be injected on the next deployment.",
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to save runtime envFrom settings."
+      toast({
+        title: "Save failed",
+        description: message,
+        variant: "destructive",
+      })
+    } finally {
+      setConfigSaving(false)
+    }
   }
 
   // 사용자 인증 상태 확인
@@ -420,11 +492,20 @@ export function DeploymentStatusMonitoring({
                     </div>
 
                     {/* Actions */}
-                    <div className="flex gap-2">
+                    <div className="grid grid-cols-2 gap-2 lg:grid-cols-5">
                       <Button
                         size="default"
                         variant="outline"
-                        className="flex-1"
+                        className="w-full"
+                        onClick={() => handleViewDetails(repo)}
+                      >
+                        <Eye className="mr-2 h-4 w-4" />
+                        Config
+                      </Button>
+                      <Button
+                        size="default"
+                        variant="outline"
+                        className="w-full"
                         onClick={() => handleOpenScale(repo)}
                       >
                         <Scale className="mr-2 h-4 w-4" />
@@ -433,7 +514,7 @@ export function DeploymentStatusMonitoring({
                       <Button
                         size="default"
                         variant="outline"
-                        className="flex-1"
+                        className="w-full"
                         onClick={() => handleOpenRollback(repo)}
                       >
                         <RotateCcw className="mr-2 h-4 w-4" />
@@ -442,7 +523,7 @@ export function DeploymentStatusMonitoring({
                       <Button
                         size="default"
                         variant="outline"
-                        className="flex-1"
+                        className="w-full"
                         onClick={() => handleOpenRestart(repo)}
                       >
                         <Play className="mr-2 h-4 w-4" />
@@ -451,7 +532,7 @@ export function DeploymentStatusMonitoring({
                       <Button
                         size="default"
                         variant="outline"
-                        className="flex-1"
+                        className="w-full"
                         onClick={() => handleOpenLogs(repo)}
                       >
                         <Terminal className="mr-2 h-4 w-4" />
@@ -473,7 +554,7 @@ export function DeploymentStatusMonitoring({
 
       {/* Details Dialog */}
       <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
-        <DialogContent className="max-w-3xl">
+        <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-3xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Github className="h-5 w-5" />
@@ -666,6 +747,47 @@ export function DeploymentStatusMonitoring({
                         {selectedRepo.auto_deploy_enabled ? "Enabled" : "Disabled"}
                       </Badge>
                     </div>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Runtime envFrom</CardTitle>
+                    <CardDescription>
+                      Store Kubernetes ConfigMap and Secret names for deployment-time environment sources.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="env-from-configmaps">ConfigMap names</Label>
+                      <Textarea
+                        id="env-from-configmaps"
+                        value={envFromConfigMapsInput}
+                        onChange={(event) => setEnvFromConfigMapsInput(event.target.value)}
+                        placeholder="smart-sousvide-runtime-config"
+                        className="min-h-20 font-mono text-sm"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Separate multiple names with commas or new lines.
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="env-from-secrets">Secret names</Label>
+                      <Textarea
+                        id="env-from-secrets"
+                        value={envFromSecretsInput}
+                        onChange={(event) => setEnvFromSecretsInput(event.target.value)}
+                        placeholder="smart-sousvide-app-env"
+                        className="min-h-20 font-mono text-sm"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Only Secret names are stored. Secret values are never shown or submitted here.
+                      </p>
+                    </div>
+                    <Button onClick={handleSaveRuntimeEnvFrom} disabled={configSaving}>
+                      <Save className="mr-2 h-4 w-4" />
+                      {configSaving ? "Saving..." : "Save runtime envFrom"}
+                    </Button>
                   </CardContent>
                 </Card>
               </TabsContent>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -600,24 +600,27 @@ class ApiClient {
         (r: any) => r.owner === owner && r.repo_name === repo
       )
       if (!targetRepo) throw new Error('Repository not found')
-      return this.request<DeploymentConfigResponse>(
+      const config = await this.request<DeploymentConfigResponse>(
         `/api/v1/repositories/${targetRepo.id}/config`
       )
+      return normalizeDeploymentConfigResponse(owner, repo, config)
     } catch {
-      return {
+      return normalizeDeploymentConfigResponse(owner, repo, {
         owner,
         repo,
-        replica_count: 1,
-        is_default: true,
-        last_scaled_at: null,
-        last_scaled_by: null,
-        created_at: null,
-        updated_at: null,
-      }
+        min_replicas: 1,
+        max_replicas: 1,
+        env_vars: {},
+        env_from_config_maps: [],
+        env_from_secrets: [],
+        container_port: 8080,
+        domain_url: null,
+      })
     }
   }
 
   async updateDeploymentConfig(owner: string, repo: string, replicaCount: number): Promise<any> {
+    const currentConfig = await this.getDeploymentConfig(owner, repo)
     const repos = await this.request<any[]>('/api/v1/repositories')
     const targetRepo = (repos || []).find(
       (r: any) => r.owner === owner && r.repo_name === repo
@@ -629,10 +632,51 @@ class ApiClient {
       body: JSON.stringify({
         min_replicas: replicaCount,
         max_replicas: replicaCount,
-        env_vars: {},
-        container_port: 8080,
+        env_vars: currentConfig.env_vars,
+        env_from_config_maps: currentConfig.env_from_config_maps,
+        env_from_secrets: currentConfig.env_from_secrets,
+        container_port: currentConfig.container_port,
+        domain_url: currentConfig.domain_url,
+        build_strategy: currentConfig.build_strategy,
+        image_uri_template: currentConfig.image_uri_template,
+        image_pull_secret_name: currentConfig.image_pull_secret_name,
+        service_type: currentConfig.service_type,
+        node_port: currentConfig.node_port,
       }),
     })
+  }
+
+  async updateDeploymentRuntimeEnvFrom(
+    owner: string,
+    repo: string,
+    envFromConfigMaps: readonly string[],
+    envFromSecrets: readonly string[]
+  ): Promise<DeploymentConfigResponse> {
+    const currentConfig = await this.getDeploymentConfig(owner, repo)
+    const repos = await this.request<any[]>('/api/v1/repositories')
+    const targetRepo = (repos || []).find(
+      (r: any) => r.owner === owner && r.repo_name === repo
+    )
+    if (!targetRepo) throw new Error('Repository not found')
+
+    const updatedConfig = await this.request<DeploymentConfigResponse>(`/api/v1/repositories/${targetRepo.id}/config`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        min_replicas: currentConfig.min_replicas,
+        max_replicas: currentConfig.max_replicas,
+        env_vars: currentConfig.env_vars,
+        env_from_config_maps: envFromConfigMaps,
+        env_from_secrets: envFromSecrets,
+        container_port: currentConfig.container_port,
+        domain_url: currentConfig.domain_url,
+        build_strategy: currentConfig.build_strategy,
+        image_uri_template: currentConfig.image_uri_template,
+        image_pull_secret_name: currentConfig.image_pull_secret_name,
+        service_type: currentConfig.service_type,
+        node_port: currentConfig.node_port,
+      }),
+    })
+    return normalizeDeploymentConfigResponse(owner, repo, updatedConfig)
   }
 
   async getScalingHistory(owner: string, repo: string, limit: number = 20): Promise<ScalingHistoryResponse> {
@@ -753,14 +797,51 @@ export interface RollbackListResponse {
 }
 
 export interface DeploymentConfigResponse {
-  owner: string
-  repo: string
+  id?: number
+  repository_id?: number
+  owner?: string
+  repo?: string
+  min_replicas: number
+  max_replicas: number
   replica_count: number
-  is_default: boolean
-  last_scaled_at: string | null
-  last_scaled_by: string | null
-  created_at: string | null
-  updated_at: string | null
+  env_vars: Record<string, string>
+  env_from_config_maps: string[]
+  env_from_secrets: string[]
+  container_port: number
+  domain_url: string | null
+  build_strategy?: string | null
+  image_uri_template?: string | null
+  image_pull_secret_name?: string | null
+  service_type?: string | null
+  node_port?: number | null
+  is_default?: boolean
+  last_scaled_at?: string | null
+  last_scaled_by?: string | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+function normalizeDeploymentConfigResponse(
+  owner: string,
+  repo: string,
+  config: Omit<DeploymentConfigResponse, 'replica_count'> & { readonly replica_count?: number }
+): DeploymentConfigResponse {
+  const maxReplicas = config.max_replicas ?? config.replica_count ?? 1
+  const minReplicas = config.min_replicas ?? maxReplicas
+
+  return {
+    ...config,
+    owner,
+    repo,
+    min_replicas: minReplicas,
+    max_replicas: maxReplicas,
+    replica_count: config.replica_count ?? maxReplicas,
+    env_vars: config.env_vars ?? {},
+    env_from_config_maps: config.env_from_config_maps ?? [],
+    env_from_secrets: config.env_from_secrets ?? [],
+    container_port: config.container_port ?? 8080,
+    domain_url: config.domain_url ?? null,
+  }
 }
 
 export interface ScalingHistoryResponse {


### PR DESCRIPTION
## Summary
- persist envFrom ConfigMap and Secret names on deployment configs and expose them through config DTOs
- inject envFrom sources into generated Kubernetes Deployment manifests while preserving envVars, imagePullSecret, containerPort, and NodePort behavior
- add console configuration fields for ConfigMap and Secret names only; secret values are never requested or shown
- validate envFrom names and fail deployment with clear missing ConfigMap/Secret messages

## Why
Smart Sousvide on Oracle k3s needed runtime ConfigMap/Secret envFrom references for MySQL, Redis, MQTT, and InfluxDB. Directly patching the live Kubernetes Deployment works only until K-Le-PaaS regenerates the Deployment, so these references need to live in the deployment config and be applied on every redeploy.

## Verification
- `sh ./gradlew :backend:test`
- `npm run build`
- Playwright production UI QA: opened Deployments, Config tab, edited runtime envFrom names at 780x493, saved, and verified the PUT payload preserved existing config while sending only ConfigMap/Secret names

Closes #41